### PR TITLE
change time datatypes to builtin int128

### DIFF
--- a/.github/workflows/run_test_and_examples.yml
+++ b/.github/workflows/run_test_and_examples.yml
@@ -15,8 +15,6 @@ jobs:
           - os: ubuntu-24.04-arm
             compiler: gcc-14
           - os: ubuntu-24.04-arm
-            compiler: clang-19
-          - os: ubuntu-24.04-arm
             compiler: clang-20
 
           - os: warp-macos-15-arm64-6x

--- a/.github/workflows/run_test_for_coverage.yml
+++ b/.github/workflows/run_test_for_coverage.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             compiler: gcc-13
       fail-fast: false
     name: ${{ matrix.config.compiler }}, ${{ matrix.config.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,17 @@ target_link_libraries(rdf4cpp
         highway::highway
         )
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # fix __mulodi4 not being available on arm
+    # https://bugs.llvm.org/show_bug.cgi?id=16404
+    # link with both gcc and clangs runtime lib
+    target_link_libraries(rdf4cpp
+            PUBLIC
+            "-rtlib=compiler-rt"
+            "-lgcc_s"
+    )
+endif()
+
 set_target_properties(rdf4cpp PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,17 +179,6 @@ target_link_libraries(rdf4cpp
         highway::highway
         )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    # fix __mulodi4 not being available on arm
-    # https://bugs.llvm.org/show_bug.cgi?id=16404
-    # link with both gcc and clangs runtime lib
-    target_link_libraries(rdf4cpp
-            PUBLIC
-            "-rtlib=compiler-rt"
-            "-lgcc_s"
-    )
-endif()
-
 set_target_properties(rdf4cpp PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ and with it its associated limits. The seconds part of the duration supports nan
 
 
 ## Supported Platforms
-- **Linux distributions (x86-64, AArch64)** (e.g. Ubuntu>=24.04, Fedora>=41, etc.) with:
-    - GCC>=14 (libstdc++>=14; used with both GCC and Clang)
-    - Clang>=19
-    - glibc 2.35+ or musl 1.2.4+
-- **macOS (ARM64)**: macOS Sonoma (14)+ with GCC>=14 (via Homebrew)
+- **Linux distributions (x86-64, aarch64)** (e.g. Ubuntu>=24.04, Fedora>=41, etc.) with:
+    - gcc>=14 (libstdc++>=14; used with both GCC and Clang)
+    - clang>=19* (on aarch64 clang>=20 is required)
+    - glibc>=2.35 or musl>=1.2.4
+- **macOS (aarch64)**: macOS Sonoma (>=14) with GCC>=14 (via Homebrew)
 
 ## Stability
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ with the usual range of `[-2^127,2^127-1]`
 And `http://www.w3.org/2001/XMLSchema#decimal` is composed of the following parts: `i/10^k`,
 where `i` is a signed 128-bit integer (`[-2^127,2^127-1]`) and `k` is an unsigned 64-bit integer (`[0,2^64]`).
 
-Above limits can be lifted by defining `RDF4CPP_USE_UNLIMITED_DATATYPES`.
-
 For `http://www.w3.org/2001/XMLSchema#dateTime` (and all derived types) there are 2 limits:
 - represented as a time point with nanosecond precision with a 128-bit signed integer
 - the year part alone in a 64-bit signed integer
@@ -140,7 +138,6 @@ and with it its associated limits. The seconds part of the duration supports nan
 - `-DBUILD_EXAMPLES=ON/OFF [default: OFF]`: Build the examples.
 - `-DBUILD_TESTING=ON/OFF [default: OFF]`: Build the tests.
 - `-DBUILD_SHARED_LIBS=ON/OFF [default: OFF]`: Build a shared library instead of a static one.
-- `-DRDF4CPP_USE_UNLIMITED_DATATYPES=ON`: If defined, uses unlimited datatypes for integer and decimal types.
 
 
 ## Supported Platforms

--- a/README.md
+++ b/README.md
@@ -113,11 +113,34 @@ cd build_dir
 sudo make install
 ```
 
+### Limits for Datatypes
+By default, unlimited precision datatypes are limited in accordance with https://www.w3.org/TR/xmlschema11-2/#partial-implementation .
+
+For `http://www.w3.org/2001/XMLSchema#integer`
+(and the related: `http://www.w3.org/2001/XMLSchema#nonNegativeInteger`
+`http://www.w3.org/2001/XMLSchema#positiveInteger` `http://www.w3.org/2001/XMLSchema#nonPositiveInteger`
+`http://www.w3.org/2001/XMLSchema#negativeInteger`) this limit is a signed 128-bit integer
+with the usual range of `[-2^127,2^127-1]`
+
+And `http://www.w3.org/2001/XMLSchema#decimal` is composed of the following parts: `i/10^k`,
+where `i` is a signed 128-bit integer (`[-2^127,2^127-1]`) and `k` is an unsigned 64-bit integer (`[0,2^64]`).
+
+Above limits can be lifted by defining `RDF4CPP_USE_UNLIMITED_DATATYPES`.
+
+For `http://www.w3.org/2001/XMLSchema#dateTime` (and all derived types) there are 2 limits:
+- represented as a time point with nanosecond precision with a 128-bit signed integer
+- the year part alone in a 64-bit signed integer
+Both limits are enough to cover both the current best theories of the big bang and the projected heat death of the universe.
+
+For `http://www.w3.org/2001/XMLSchema#duration` (and all derived types), both parts have a separate signed 64-bit integer
+and with it its associated limits. The seconds part of the duration supports nanosecond precision.
+
 ### Additional CMake config options:
 
 - `-DBUILD_EXAMPLES=ON/OFF [default: OFF]`: Build the examples.
 - `-DBUILD_TESTING=ON/OFF [default: OFF]`: Build the tests.
 - `-DBUILD_SHARED_LIBS=ON/OFF [default: OFF]`: Build a shared library instead of a static one.
+- `-DRDF4CPP_USE_UNLIMITED_DATATYPES=ON`: If defined, uses unlimited datatypes for integer and decimal types.
 
 
 ## Supported Platforms

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 
 from conan import ConanFile
 
@@ -19,15 +19,16 @@ class Recipe(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_test_deps": [True, False],
+        "unlimited_datatypes": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_test_deps": False,
+        "unlimited_datatypes": False,
     }
     exports = "LICENSE",
     exports_sources = "src/*", "private/*", "CMakeLists.txt", "cmake/*"
-    generators = ("CMakeDeps", "CMakeToolchain")
 
     def requirements(self):
         self.requires("boost/1.86.0", transitive_headers=True, libs=False)
@@ -57,6 +58,12 @@ class Recipe(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.options.unlimited_datatypes:
+            tc.preprocessor_definitions["RDF4CPP_USE_UNLIMITED_DATATYPES"] = "1"
+        tc.generate()
 
     def layout(self):
         cmake_layout(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
+from conan.tools.cmake import cmake_layout, CMake
 
 from conan import ConanFile
 
@@ -19,16 +19,15 @@ class Recipe(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_test_deps": [True, False],
-        "unlimited_datatypes": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_test_deps": False,
-        "unlimited_datatypes": False,
     }
     exports = "LICENSE",
     exports_sources = "src/*", "private/*", "CMakeLists.txt", "cmake/*"
+    generators = ("CMakeDeps", "CMakeToolchain")
 
     def requirements(self):
         self.requires("boost/1.86.0", transitive_headers=True, libs=False)
@@ -58,14 +57,6 @@ class Recipe(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        if self.options.unlimited_datatypes:
-            tc.preprocessor_definitions["RDF4CPP_USE_UNLIMITED_DATATYPES"] = "1"
-        tc.generate()
-        cmake = CMakeDeps(self)
-        cmake.generate()
 
     def layout(self):
         cmake_layout(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 
 from conan import ConanFile
 
@@ -64,6 +64,8 @@ class Recipe(ConanFile):
         if self.options.unlimited_datatypes:
             tc.preprocessor_definitions["RDF4CPP_USE_UNLIMITED_DATATYPES"] = "1"
         tc.generate()
+        cmake = CMakeDeps(self)
+        cmake.generate()
 
     def layout(self):
         cmake_layout(self)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -71,4 +71,3 @@ ________________________________
 * :code:`-DBUILD_EXAMPLES=ON/OFF [default: OFF]`: Build the examples.
 * :code:`-DBUILD_TESTING=ON/OFF [default: OFF]`: Build  the tests.
 * :code:`-DBUILD_SHARED_LIBS=ON/OFF [default: OFF]`: Build a shared library instead of a static one.
-* :code:`-DRDF4CPP_USE_UNLIMITED_DATATYPES=ON`: If defined, uses unlimited datatypes for integer and decimal types.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -71,4 +71,4 @@ ________________________________
 * :code:`-DBUILD_EXAMPLES=ON/OFF [default: OFF]`: Build the examples.
 * :code:`-DBUILD_TESTING=ON/OFF [default: OFF]`: Build  the tests.
 * :code:`-DBUILD_SHARED_LIBS=ON/OFF [default: OFF]`: Build a shared library instead of a static one.
-* :code:`-DUSE_CONAN=ON/OFF [default: ON]`: If available, use Conan to retrieve dependencies.
+* :code:`-DRDF4CPP_USE_UNLIMITED_DATATYPES=ON`: If defined, uses unlimited datatypes for integer and decimal types.

--- a/docs/source/users_guide.rst
+++ b/docs/source/users_guide.rst
@@ -36,6 +36,33 @@ You can find all supported Datatypes here:
  * :ref:`namespace_rdf4cpp__datatypes__rdf`: RDF datatypes (LangString).
  * :ref:`namespace_rdf4cpp__datatypes__owl`: OWL datatypes.
 
+
+Limits for Datatypes
+++++++++++++++++++++
+By default, unlimited precision datatypes are limited in accordance with https://www.w3.org/TR/xmlschema11-2/#partial-implementation .
+
+For :code:`http://www.w3.org/2001/XMLSchema#integer`
+(and the related: :code:`http://www.w3.org/2001/XMLSchema#nonNegativeInteger`
+:code:`http://www.w3.org/2001/XMLSchema#positiveInteger` :code:`http://www.w3.org/2001/XMLSchema#nonPositiveInteger`
+:code:`http://www.w3.org/2001/XMLSchema#negativeInteger`) this limit is a signed 128-bit integer
+with the usual range of :code:`[-2^127,2^127-1]`
+
+And :code:`http://www.w3.org/2001/XMLSchema#decimal` is composed of the following parts: :code:`i/10^k`,
+where :code:`i` is a signed 128-bit integer (:code:`[-2^127,2^127-1]`) and :code:`k` is an unsigned 64-bit integer (:code:`[0,2^64]`).
+
+Above limits can be lifted by defining :code:`RDF4CPP_USE_UNLIMITED_DATATYPES`.
+
+For :code:`http://www.w3.org/2001/XMLSchema#dateTime` (and all derived types) there are 2 limits:
+
+* represented as a time point with nanosecond precision with a 128-bit signed integer
+* the year part alone in a 64-bit signed integer
+
+Both limits are enough to cover both the current best theories of the big bang and the projected heat death of the universe.
+
+For :code:`http://www.w3.org/2001/XMLSchema#duration` (and all derived types), both parts have a separate signed 64-bit integer
+and with it its associated limits. The seconds part of the duration supports nanosecond precision.
+
+
 Parsing Files
 -------------
 

--- a/docs/source/users_guide.rst
+++ b/docs/source/users_guide.rst
@@ -49,9 +49,7 @@ with the usual range of :code:`[-2^127,2^127-1]`
 
 And :code:`http://www.w3.org/2001/XMLSchema#decimal` is composed of the following parts: :code:`i/10^k`,
 where :code:`i` is a signed 128-bit integer (:code:`[-2^127,2^127-1]`) and :code:`k` is an unsigned 64-bit integer (:code:`[0,2^64]`).
-
-Above limits can be lifted by defining :code:`RDF4CPP_USE_UNLIMITED_DATATYPES`.
-
+ss
 For :code:`http://www.w3.org/2001/XMLSchema#dateTime` (and all derived types) there are 2 limits:
 
 * represented as a time point with nanosecond precision with a 128-bit signed integer

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -30,7 +30,7 @@ enum struct DecimalError {
 template<typename T>
 concept BigDecimalBaseType = std::numeric_limits<T>::is_specialized && !std::floating_point<T>;
 
-template<BigDecimalBaseType UnscaledValue_t = util::BigInt, BigDecimalBaseType Exponent_t = uint32_t>
+template<BigDecimalBaseType UnscaledValue_t = util::Int128, BigDecimalBaseType Exponent_t = uint32_t>
 requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
 struct BigDecimal {
     // the entire class is loosely based on OpenJDKs BigDecimal: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/math/BigDecimal.java

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -11,6 +11,7 @@
 
 #include <rdf4cpp/Expected.hpp>
 #include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp {
 enum struct RoundingMode {
@@ -28,7 +29,7 @@ enum struct DecimalError {
 template<typename T>
 concept BigDecimalBaseType = std::numeric_limits<T>::is_specialized && !std::floating_point<T>;
 
-template<BigDecimalBaseType UnscaledValue_t = boost::multiprecision::checked_int128_t, BigDecimalBaseType Exponent_t = uint32_t>
+template<BigDecimalBaseType UnscaledValue_t = util::Int128, BigDecimalBaseType Exponent_t = uint32_t>
 requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
 struct BigDecimal {
     // the entire class is loosely based on OpenJDKs BigDecimal: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/math/BigDecimal.java
@@ -37,93 +38,9 @@ private:
     UnscaledValue_t unscaled_value;
     Exponent_t exponent;
 
+    using OverflowMode = util::detail::OverflowMode;
+
     static constexpr uint32_t base = 10;
-
-    enum struct OverflowMode {
-        Checked,
-        UndefinedBehavior,
-    };
-
-    template<OverflowMode m, typename T>
-    static constexpr bool add_checked(const T &a, const T &b, T &result) noexcept {
-        if constexpr (std::is_integral_v<T> && m == OverflowMode::Checked) {
-            return __builtin_add_overflow(a, b, &result);
-        } else if (m == OverflowMode::Checked) {
-            try {
-                result = a + b;
-            } catch (std::overflow_error const &) {
-                return true;
-            } catch (std::range_error const &) {
-                return true;
-            }
-            return false;
-        } else {
-            result = a + b;
-            return false;
-        }
-    }
-
-    template<OverflowMode m, typename T>
-    static constexpr bool sub_checked(const T &a, const T &b, T &result) noexcept {
-        if constexpr (std::is_integral_v<T> && m == OverflowMode::Checked) {
-            return __builtin_sub_overflow(a, b, &result);
-        } else if (m == OverflowMode::Checked) {
-            try {
-                result = a - b;
-            } catch (std::overflow_error const &) {
-                return true;
-            } catch (std::range_error const &) {
-                return true;
-            }
-            return false;
-        } else {
-            result = a - b;
-            return false;
-        }
-    }
-
-    template<OverflowMode m, typename T>
-    static constexpr bool mul_checked(const T &a, const T &b, T &result) noexcept {
-        if constexpr (std::is_integral_v<T> && m == OverflowMode::Checked) {
-            return __builtin_mul_overflow(a, b, &result);
-        } else if (m == OverflowMode::Checked) {
-            try {
-                result = a * b;
-            } catch (std::overflow_error const &) {
-                return true;
-            } catch (std::range_error const &) {
-                return true;
-            }
-            return false;
-        } else {
-            result = a * b;
-            return false;
-        }
-    }
-
-    template<OverflowMode m, typename T>
-    static constexpr bool pow_checked(const T &a, unsigned int b, T &result) noexcept {
-        if constexpr (std::is_integral_v<T>) {
-            T r = 1;
-            bool over = false;
-            for (unsigned int i = 0; i < b; ++i)
-                over |= mul_checked<m, T>(r, a, r);
-            result = r;
-            return over;
-        } else if (m == OverflowMode::Checked) {
-            try {
-                result = boost::multiprecision::pow(a, b);
-            } catch (std::overflow_error const &) {
-                return true;
-            } catch (std::range_error const &) {
-                return true;
-            }
-            return false;
-        } else {
-            result = boost::multiprecision::pow(a, b);
-            return false;
-        }
-    }
 
     template<OverflowMode m, typename To, typename From>
     static constexpr bool cast_checked(const From &f, To &result) noexcept {
@@ -196,14 +113,14 @@ public:
                 throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: non-numeric char found"};
             }
             auto n = c - '0';
-            if (mul_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{base}, unscaled_value)) {
+            if (util::detail::mul_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{base}, unscaled_value)) {
                 throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: unscaled_value overflow"};
             }
-            if (add_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{n}, unscaled_value)) {
+            if (util::detail::add_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{n}, unscaled_value)) {
                 throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: unscaled_value overflow"};
             }
             if (decimal) {
-                if (add_checked<OverflowMode::Checked>(exponent, Exponent_t{1}, exponent)) {
+                if (util::detail::add_checked<OverflowMode::Checked>(exponent, Exponent_t{1}, exponent)) {
                     throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: exponent overflow"};
                 }
             }
@@ -257,14 +174,10 @@ public:
      */
     constexpr explicit BigDecimal(float value) : BigDecimal(static_cast<double>(value)) {}
 
-    /**
-     * converts a double to a BigDecimal.
-     * this conversion might not be exact, due to the built in limitations of doubles.
-     * if you have the possibility, use one of the other constructors.
-     * @param value
-     * @throw std::overflow_error on exceeding the types numeric limits
-     */
-    explicit BigDecimal(double value) : unscaled_value(0), exponent(0) {
+private:
+    void from_double_direct(double value)
+    requires(std::numeric_limits<UnscaledValue_t>::digits >= std::numeric_limits<boost::multiprecision::int1024_t>::digits)
+    {
         // most of the algorithm is from OpenJDK: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/classes/java/math/BigDecimal.java#L915
         if (std::isinf(value) || std::isnan(value))
             throw std::invalid_argument{"value is NaN or infinity"};
@@ -276,7 +189,7 @@ public:
         // 63   | 62 ... 52 | 51 ... 0
         // see https://en.wikipedia.org/wiki/Double-precision_floating-point_format for more info (and a better graphic)
         auto v = std::bit_cast<uint64_t>(value);
-        bool neg = (v >> 63) != 0;
+        bool const neg = (v >> 63) != 0;
         auto ex = static_cast<int>((v >> 52) & 0x7ffL);
         uint64_t significand = ex == 0
                                        ? (v & ((1L << 52) - 1)) << 1
@@ -295,20 +208,40 @@ public:
         } else if (ex < 0) {
             exponent = static_cast<Exponent_t>(-ex);
             UnscaledValue_t e{0};
-            if (pow_checked<OverflowMode::Checked>(UnscaledValue_t{5}, -ex, e))
+            if (util::detail::pow_checked<OverflowMode::Checked>(UnscaledValue_t{5}, -ex, e))
                 throw std::overflow_error{exc};
-            if (mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
+            if (util::detail::mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
                 throw std::overflow_error{exc};
         } else {
             UnscaledValue_t e{0};
-            if (pow_checked<OverflowMode::Checked>(UnscaledValue_t{2}, ex, e))
+            if (util::detail::pow_checked<OverflowMode::Checked>(UnscaledValue_t{2}, ex, e))
                 throw std::overflow_error{exc};
-            if (mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
+            if (util::detail::mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
                 throw std::overflow_error{exc};
         }
         if (neg)
             unscaled_value = -unscaled_value;
         normalize();
+    }
+
+public:
+    /**
+     * converts a double to a BigDecimal.
+     * this conversion might not be exact, due to the built in limitations of doubles.
+     * if you have the possibility, use one of the other constructors.
+     * @param value
+     * @throw std::overflow_error on exceeding the types numeric limits
+     */
+    explicit BigDecimal(double value) : unscaled_value(0), exponent(0) {
+        if constexpr (std::numeric_limits<UnscaledValue_t>::digits >= std::numeric_limits<boost::multiprecision::int1024_t>::digits) {
+            from_double_direct(value);
+        } else {
+            BigDecimal<boost::multiprecision::checked_int1024_t> const v{value};
+            if (cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value))
+                throw std::overflow_error{"double to BigDecimal overflow"};
+            if (cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent))
+                throw std::overflow_error{"double to BigDecimal overflow"};
+        }
     }
 
     /**
@@ -349,15 +282,15 @@ private:
         Exponent_t new_exp = std::max(this->exponent, other.exponent);
         if (this->exponent < new_exp) {
             UnscaledValue_t ex{0};
-            if (pow_checked<m>(UnscaledValue_t{base}, new_exp - this->exponent, ex))
+            if (util::detail::pow_checked<m>(UnscaledValue_t{base}, new_exp - this->exponent, ex))
                 return true;
-            if (mul_checked<m>(t, ex, t))
+            if (util::detail::mul_checked<m>(t, ex, t))
                 return true;
         } else if (other.exponent < new_exp) {
             UnscaledValue_t ex{0};
-            if (pow_checked<m>(UnscaledValue_t{base}, new_exp - other.exponent, ex))
+            if (util::detail::pow_checked<m>(UnscaledValue_t{base}, new_exp - other.exponent, ex))
                 return true;
-            if (mul_checked<m>(o, ex, o))
+            if (util::detail::mul_checked<m>(o, ex, o))
                 return true;
         }
         UnscaledValue_t res = 0;
@@ -370,10 +303,10 @@ private:
     template<OverflowMode m>
     constexpr bool mul(const BigDecimal &other, BigDecimal &result) const noexcept {
         UnscaledValue_t v{0};
-        if (mul_checked<m>(this->unscaled_value, other.unscaled_value, v))
+        if (util::detail::mul_checked<m>(this->unscaled_value, other.unscaled_value, v))
             return true;
         Exponent_t e{0};
-        if (add_checked<m>(this->exponent, other.exponent, e))
+        if (util::detail::add_checked<m>(this->exponent, other.exponent, e))
             return true;
         result = BigDecimal{v, e};
         return false;
@@ -423,18 +356,18 @@ private:
         Exponent_t ex = this->exponent;
         UnscaledValue_t div = other.unscaled_value;
         if (ex >= other.exponent) {
-            if (sub_checked<m>(ex, other.exponent, ex))
+            if (util::detail::sub_checked<m>(ex, other.exponent, ex))
                 return true;
         } else {
             Exponent_t tmp{0};
-            if (sub_checked<m>(other.exponent, ex, tmp))
+            if (util::detail::sub_checked<m>(other.exponent, ex, tmp))
                 return true;
-            if (pow_checked<m>(Exponent_t{base}, tmp, tmp))
+            if (util::detail::pow_checked<m>(Exponent_t{base}, tmp, tmp))
                 return true;
             UnscaledValue_t tmp2{0};
             if (cast_checked<m>(tmp, tmp2))
                 return true;
-            if (mul_checked<m>(t, tmp2, t))
+            if (util::detail::mul_checked<m>(t, tmp2, t))
                 return true;
             ex = 0;
         }
@@ -442,23 +375,23 @@ private:
         UnscaledValue_t rem = t % div;
         while (rem != 0) {
             if (max_scale_increase == 0) {
-                if (mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+                if (util::detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
                     return true;
                 result = handle_rounding(res, ex, rem / div, mode);
                 return false;
             }
             if constexpr (std::is_integral_v<Exponent_t>) {
                 if (ex == std::numeric_limits<Exponent_t>::max()) {
-                    if (mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+                    if (util::detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
                         return true;
                     result = handle_rounding(res, ex, rem / div, mode);
                     return false;
                 }
             }
             ++ex;
-            if (mul_checked<m>(res, UnscaledValue_t{base}, res))
+            if (util::detail::mul_checked<m>(res, UnscaledValue_t{base}, res))
                 return true;
-            if (mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+            if (util::detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
                 return true;
             res += rem / div;
             rem = rem % div;
@@ -538,7 +471,7 @@ public:
      */
     [[nodiscard]] constexpr BigDecimal operator+(const BigDecimal &other) const noexcept {
         BigDecimal res{0};
-        add_or_sub<OverflowMode::UndefinedBehavior, add_checked<OverflowMode::UndefinedBehavior, UnscaledValue_t>>(other, res);
+        add_or_sub<OverflowMode::UndefinedBehavior, util::detail::add_checked<OverflowMode::UndefinedBehavior>>(other, res);
         return res;
     }
     /**
@@ -549,7 +482,7 @@ public:
      */
     [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> add_checked(const BigDecimal &other) const noexcept {
         BigDecimal res{0};
-        if (add_or_sub<OverflowMode::Checked, add_checked<OverflowMode::Checked, UnscaledValue_t>>(other, res))
+        if (add_or_sub<OverflowMode::Checked, util::detail::add_checked<OverflowMode::Checked>>(other, res))
             return nonstd::make_unexpected(DecimalError::Overflow);
         return res;
     }
@@ -573,7 +506,7 @@ public:
      */
     [[nodiscard]] constexpr BigDecimal operator-(const BigDecimal &other) const noexcept {
         BigDecimal res{0};
-        add_or_sub<OverflowMode::UndefinedBehavior, sub_checked<OverflowMode::UndefinedBehavior, UnscaledValue_t>>(other, res);
+        add_or_sub<OverflowMode::UndefinedBehavior, util::detail::sub_checked<OverflowMode::UndefinedBehavior>>(other, res);
         return res;
     }
 
@@ -585,7 +518,7 @@ public:
      */
     [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> sub_checked(const BigDecimal &other) const noexcept {
         BigDecimal res{0};
-        if (add_or_sub<OverflowMode::Checked, sub_checked<OverflowMode::Checked, UnscaledValue_t>>(other, res))
+        if (add_or_sub<OverflowMode::Checked, util::detail::sub_checked<OverflowMode::Checked>>(other, res))
             return nonstd::make_unexpected(DecimalError::Overflow);
         return res;
     }
@@ -730,7 +663,7 @@ public:
         if (exponent == 0)
             return *this;
         UnscaledValue_t v{base};
-        if (pow_checked<OverflowMode::Checked>(v, exponent, v))
+        if (util::detail::pow_checked<OverflowMode::Checked>(v, exponent, v))
             return BigDecimal{0, 0};  // base pow exponent overflows and this did not, we have to be close to 0
         UnscaledValue_t rem = unscaled_value % v;
         rem = rem * 10 / v;
@@ -774,15 +707,15 @@ public:
         UnscaledValue_t o = other.unscaled_value;
         if (this->exponent > other.exponent) {
             UnscaledValue_t b{base};
-            if (pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))
+            if (util::detail::pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))
                 return std::strong_ordering::less;  // t does fit into the same precision, while o does not
-            if (mul_checked<OverflowMode::Checked>(o, b, o))
+            if (util::detail::mul_checked<OverflowMode::Checked>(o, b, o))
                 return std::strong_ordering::less;  // t does fit into the same precision, while o does not
         } else if (this->exponent < other.exponent) {
             UnscaledValue_t b{base};
-            if (pow_checked<OverflowMode::Checked>(b, other.exponent - this->exponent, b))
+            if (util::detail::pow_checked<OverflowMode::Checked>(b, other.exponent - this->exponent, b))
                 return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
-            if (mul_checked<OverflowMode::Checked>(t, b, t))
+            if (util::detail::mul_checked<OverflowMode::Checked>(t, b, t))
                 return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
         }
         if (t < o)
@@ -863,8 +796,9 @@ public:
         bool hasDot = false;
         while (v != 0) {
             if (!hasDot && ex == 0) {
-                if (s.view().empty())
+                if (s.view().empty()) {
                     s << '0';
+                }
                 s << '.';
                 hasDot = true;
             } else {
@@ -872,17 +806,20 @@ public:
             }
             using namespace std;
             auto c = static_cast<uint32_t>(abs(v % base));
-            if (hasDot || c != 0 || !s.view().empty())  // skip trailing 0s
+            if (hasDot || c != 0 || !s.view().empty()) {  // skip trailing 0s
                 s << c;
+            }
             v /= base;
         }
         if (!hasDot) {
-            for (Exponent_t i = 0; i < ex; ++i)
+            for (Exponent_t i = 0; i < ex; ++i) {
                 s << '0';
+            }
             s << ".0";
         }
-        if (!positive())
+        if (!positive()) {
             s << '-';
+        }
         std::string_view sv = s.view();
         return std::string{sv.rbegin(), sv.rend()};
     }

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -30,7 +30,7 @@ enum struct DecimalError {
 template<typename T>
 concept BigDecimalBaseType = std::numeric_limits<T>::is_specialized && !std::floating_point<T>;
 
-template<BigDecimalBaseType UnscaledValue_t = util::Int128, BigDecimalBaseType Exponent_t = uint32_t>
+template<BigDecimalBaseType UnscaledValue_t = util::BigInt, BigDecimalBaseType Exponent_t = uint32_t>
 requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
 struct BigDecimal {
     // the entire class is loosely based on OpenJDKs BigDecimal: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/math/BigDecimal.java

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -226,8 +226,6 @@ public:
                         continue;
                     }
                     throw std::overflow_error{"double -> decimal unscaled value overflow"};
-                    //auto f = std::format("{:f}", value);
-                    //*this = BigDecimal(f);
                 }
                 return;
             }
@@ -561,15 +559,21 @@ public:
     }
 
     /**
+     * default value for scale increase when using operators.
+     * when this many decimal places have been added, stop dividing and floor.
+     */
+    static constexpr Exponent_t default_max_scale_increase = 20;
+
+    /**
      * division of two BigDecimals.
      * may overflow.
-     * after 1000 decimal places have been added, stops dividing and floor.
+     * after default_max_scale_increase decimal places have been added, stops dividing and floor.
      * dividing by 0 is undefined behavior.
      * @param other
      * @return
      */
     [[nodiscard]] constexpr BigDecimal operator/(const BigDecimal &other) const noexcept {
-        return div(other, 1000);
+        return div(other, default_max_scale_increase);
     }
 
     /**
@@ -703,7 +707,9 @@ public:
             return this->positive() ? std::strong_ordering::greater : std::strong_ordering::less;
         UnscaledValue_t t = this->unscaled_value;
         UnscaledValue_t o = other.unscaled_value;
-        if (t != 0 && o != 0) {  // if one of the decimals is 0, compare directly (0*base^e is 0 for all e)
+        // scale both values to have the same exponent
+        // if one of the decimals is 0, skip and compare directly (0*base^e is 0 for all e)
+        if (t != 0 && o != 0) {
             if (this->exponent > other.exponent) {
                 UnscaledValue_t b{base};
                 if (util::detail::pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -28,8 +28,8 @@ enum struct DecimalError {
 template<typename T>
 concept BigDecimalBaseType = std::numeric_limits<T>::is_specialized && !std::floating_point<T>;
 
-template<BigDecimalBaseType UnscaledValue_t = boost::multiprecision::cpp_int, BigDecimalBaseType Exponent_t = uint32_t>
-    requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
+template<BigDecimalBaseType UnscaledValue_t = boost::multiprecision::checked_int128_t, BigDecimalBaseType Exponent_t = uint32_t>
+requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
 struct BigDecimal {
     // the entire class is loosely based on OpenJDKs BigDecimal: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/math/BigDecimal.java
 
@@ -48,6 +48,15 @@ private:
     static constexpr bool add_checked(const T &a, const T &b, T &result) noexcept {
         if constexpr (std::is_integral_v<T> && m == OverflowMode::Checked) {
             return __builtin_add_overflow(a, b, &result);
+        } else if (m == OverflowMode::Checked) {
+            try {
+                result = a + b;
+            } catch (std::overflow_error const &) {
+                return true;
+            } catch (std::range_error const &) {
+                return true;
+            }
+            return false;
         } else {
             result = a + b;
             return false;
@@ -58,6 +67,15 @@ private:
     static constexpr bool sub_checked(const T &a, const T &b, T &result) noexcept {
         if constexpr (std::is_integral_v<T> && m == OverflowMode::Checked) {
             return __builtin_sub_overflow(a, b, &result);
+        } else if (m == OverflowMode::Checked) {
+            try {
+                result = a - b;
+            } catch (std::overflow_error const &) {
+                return true;
+            } catch (std::range_error const &) {
+                return true;
+            }
+            return false;
         } else {
             result = a - b;
             return false;
@@ -68,6 +86,15 @@ private:
     static constexpr bool mul_checked(const T &a, const T &b, T &result) noexcept {
         if constexpr (std::is_integral_v<T> && m == OverflowMode::Checked) {
             return __builtin_mul_overflow(a, b, &result);
+        } else if (m == OverflowMode::Checked) {
+            try {
+                result = a * b;
+            } catch (std::overflow_error const &) {
+                return true;
+            } catch (std::range_error const &) {
+                return true;
+            }
+            return false;
         } else {
             result = a * b;
             return false;
@@ -83,6 +110,15 @@ private:
                 over |= mul_checked<m, T>(r, a, r);
             result = r;
             return over;
+        } else if (m == OverflowMode::Checked) {
+            try {
+                result = boost::multiprecision::pow(a, b);
+            } catch (std::overflow_error const &) {
+                return true;
+            } catch (std::range_error const &) {
+                return true;
+            }
+            return false;
         } else {
             result = boost::multiprecision::pow(a, b);
             return false;
@@ -94,6 +130,15 @@ private:
         if constexpr (std::is_integral_v<To> && std::is_integral_v<From> && m == OverflowMode::Checked) {
             if (!std::in_range<To>(f))
                 return true;
+        } else if (m == OverflowMode::Checked) {
+            try {
+                result = static_cast<To>(f);
+            } catch (std::overflow_error const &) {
+                return true;
+            } catch (std::range_error const &) {
+                return true;
+            }
+            return false;
         }
         result = static_cast<To>(f);
         return false;
@@ -910,6 +955,12 @@ template<typename Policy>
 struct dice::hash::dice_hash_overload<Policy, ::boost::multiprecision::cpp_int> {
     static size_t dice_hash(::boost::multiprecision::cpp_int const &x) noexcept {
         return dice::hash::dice_hash_templates<Policy>::dice_hash(std::hash<::boost::multiprecision::cpp_int>{}(x));
+    }
+};
+template<typename Policy>
+struct dice::hash::dice_hash_overload<Policy, ::boost::multiprecision::checked_int128_t> {
+    static size_t dice_hash(::boost::multiprecision::checked_int128_t const &x) noexcept {
+        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::hash<::boost::multiprecision::checked_int128_t>{}(x));
     }
 };
 

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -43,25 +43,6 @@ private:
 
     static constexpr uint32_t base = 10;
 
-    template<OverflowMode m, typename To, typename From>
-    static constexpr bool cast_checked(const From &f, To &result) noexcept {
-        if constexpr (std::is_integral_v<To> && std::is_integral_v<From> && m == OverflowMode::Checked) {
-            if (!std::in_range<To>(f))
-                return true;
-        } else if (m == OverflowMode::Checked) {
-            try {
-                result = static_cast<To>(f);
-            } catch (std::overflow_error const &) {
-                return true;
-            } catch (std::range_error const &) {
-                return true;
-            }
-            return false;
-        }
-        result = static_cast<To>(f);
-        return false;
-    }
-
     static constexpr UnscaledValue_t abs(const UnscaledValue_t &value) noexcept {
         if constexpr (std::is_integral_v<UnscaledValue_t> && !std::is_signed_v<UnscaledValue_t>) {
             return value;
@@ -239,7 +220,7 @@ public:
         } else {
             BigDecimal<boost::multiprecision::checked_cpp_int> v{value};
             while (true) {
-                if (cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value) || cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent)) {
+                if (util::detail::cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value) || util::detail::cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent)) {
                     if (v.get_exponent() > 0) {
                         v = {v.get_unscaled_value() / base, v.get_exponent() - 1};
                         continue;
@@ -374,7 +355,7 @@ private:
             if (util::detail::pow_checked<m>(Exponent_t{base}, tmp, tmp))
                 return true;
             UnscaledValue_t tmp2{0};
-            if (cast_checked<m>(tmp, tmp2))
+            if (util::detail::cast_checked<m>(tmp, tmp2))
                 return true;
             if (util::detail::mul_checked<m>(t, tmp2, t))
                 return true;
@@ -669,14 +650,22 @@ public:
      * @return
      */
     [[nodiscard]] constexpr BigDecimal round(RoundingMode mode) const noexcept {
-        if (exponent == 0)
+        if (exponent == 0) {
             return *this;
+        }
         UnscaledValue_t v{base};
-        if (util::detail::pow_checked<OverflowMode::Checked>(v, exponent, v))
-            return BigDecimal{0, 0};  // base pow exponent overflows and this did not, we have to be close to 0
-        UnscaledValue_t rem = unscaled_value % v;
-        rem = rem * 10 / v;
-        v = unscaled_value / v;
+        UnscaledValue_t uns = unscaled_value;
+        if (util::detail::pow_checked<OverflowMode::Checked>(v, exponent, v)) {
+            v = {base};
+            uns /= 100;
+            if (util::detail::pow_checked<OverflowMode::Checked>(v, exponent - 2, v)) {
+                // base pow exponent overflows and this did not, we have to be close to 0
+                return BigDecimal{0, 0};
+            }
+        }
+        UnscaledValue_t rem = uns % v;
+        rem = rem / (v / base); // in rare cases, rem * 10 / v can overflow
+        v = uns / v;
         return handle_rounding(v, 0, rem, mode);
     }
 

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -1,6 +1,7 @@
 #ifndef RDF4CPP_BIGDECIMAL_H
 #define RDF4CPP_BIGDECIMAL_H
 
+#include <cmath>
 #include <format>
 #include <functional>
 #include <sstream>
@@ -15,881 +16,892 @@
 #include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp {
-enum struct RoundingMode {
-    Floor,
-    Ceil,
-    Round,
-    Trunc,
-};
+    namespace util {
+        enum struct RoundingMode {
+            Floor,
+            Ceil,
+            Round,
+            Trunc,
+        };
 
-enum struct DecimalError {
-    Overflow,
-    NotDefined,  // aka NotANumber
-};
+        enum struct DecimalError {
+            Overflow,
+            NotDefined,  // aka NotANumber
+        };
 
-template<typename T>
-concept BigDecimalBaseType = std::numeric_limits<T>::is_specialized && !std::floating_point<T>;
+        template<typename T>
+        concept BigDecimalBaseType = std::numeric_limits<T>::is_specialized && !std::floating_point<T>;
 
-template<BigDecimalBaseType UnscaledValue_t = util::Int128, BigDecimalBaseType Exponent_t = uint32_t>
-requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
-struct BigDecimal {
-    // the entire class is loosely based on OpenJDKs BigDecimal: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/math/BigDecimal.java
+        template<BigDecimalBaseType UnscaledValue_t = Int128, BigDecimalBaseType Exponent_t = uint32_t>
+        requires(!std::signed_integral<Exponent_t> && !std::unsigned_integral<UnscaledValue_t>)
+        struct BigDecimal {
+            // the entire class is loosely based on OpenJDKs BigDecimal: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/math/BigDecimal.java
 
-private:
-    UnscaledValue_t unscaled_value;
-    Exponent_t exponent;
+        private:
+            UnscaledValue_t unscaled_value;
+            Exponent_t exponent;
 
-    using OverflowMode = util::detail::OverflowMode;
+            using OverflowMode = detail::OverflowMode;
 
-    static constexpr uint32_t base = 10;
+            static constexpr uint32_t base = 10;
 
-    static constexpr UnscaledValue_t abs(const UnscaledValue_t &value) noexcept {
-        if constexpr (std::is_integral_v<UnscaledValue_t> && !std::is_signed_v<UnscaledValue_t>) {
-            return value;
-        } else {
-            return value < 0 ? -value : value;
-        }
-    }
-
-public:
-    constexpr BigDecimal() noexcept : BigDecimal{0, 0} {
-    }
-
-    /**
-     * creates a BigDecimal from its components.
-     * it has the value of unscaled_value * pow(10, -exponent).
-     * @param unscaled_value
-     * @param exponent
-     */
-    constexpr BigDecimal(const UnscaledValue_t &unscaled_value, Exponent_t exponent) noexcept
-        : unscaled_value(unscaled_value), exponent(exponent) {}
-
-    /**
-     * parses a BigDecimal from a string_view.
-     * may include a leading sign and one decimal point ., everything else needs to be numeric.
-     * @param value
-     * @throw rdf4cpp::InvalidNode if a invalid char is found, or on exceeding the types numeric limits
-     */
-    constexpr explicit BigDecimal(std::string_view value) : unscaled_value(0), exponent(0) {
-        bool begin = true;
-        bool decimal = false;
-        bool neg = false;
-        for (const char c : value) {
-            if (begin) {
-                begin = false;
-                if (c == '-') {
-                    neg = true;
-                    continue;
-                } else if (c == '+') {
-                    continue;
+            static constexpr UnscaledValue_t abs(UnscaledValue_t const &value) noexcept {
+                if constexpr (std::is_integral_v<UnscaledValue_t> && !std::is_signed_v<UnscaledValue_t>) {
+                    return value;
+                } else {
+                    return value < 0 ? -value : value;
                 }
             }
-            if (c == '.') {
-                if (decimal) {
-                    throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: more than one . found"};
-                }
-                decimal = true;
-                continue;
+
+        public:
+            constexpr BigDecimal() noexcept : BigDecimal{0, 0} {
             }
-            if (c < '0' || c > '9') {
-                throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: non-numeric char found"};
+
+            /**
+             * creates a BigDecimal from its components.
+             * it has the value of unscaled_value * pow(10, -exponent).
+             * @param unscaled_value
+             * @param exponent
+             */
+            constexpr BigDecimal(UnscaledValue_t const &unscaled_value, Exponent_t exponent) noexcept
+                : unscaled_value(unscaled_value), exponent(exponent) {
             }
-            auto n = c - '0';
-            if (util::detail::mul_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{base}, unscaled_value)) {
-                throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: unscaled_value overflow"};
-            }
-            if (util::detail::add_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{n}, unscaled_value)) {
-                throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: unscaled_value overflow"};
-            }
-            if (decimal) {
-                if (util::detail::add_checked<OverflowMode::Checked>(exponent, Exponent_t{1}, exponent)) {
-                    throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: exponent overflow"};
-                }
-            }
-        }
-        if (unscaled_value == 0) {
-            neg = false;
-        }
-        if (neg) {
-            unscaled_value = -unscaled_value;
-        }
-    }
 
-    /**
-     * converts a uint32_t to a BigDecimal
-     * @param value
-     */
-    constexpr explicit BigDecimal(uint32_t value) noexcept : BigDecimal(UnscaledValue_t{value}, 0) {}
-
-    /**
-     * converts a uint64_t to a BigDecimal
-     * @param value
-     */
-    constexpr explicit BigDecimal(uint64_t value) noexcept : BigDecimal(UnscaledValue_t{value}, 0) {}
-
-    /**
-     * converts a int32_t to a BigDecimal
-     * @param value
-     */
-    constexpr explicit BigDecimal(int32_t value) noexcept : BigDecimal(static_cast<UnscaledValue_t>(value), 0) {}
-
-    /**
-     * converts a int64_t to a BigDecimal
-     * @param value
-     */
-    constexpr explicit BigDecimal(int64_t value) noexcept : BigDecimal(static_cast<UnscaledValue_t>(value), 0) {}
-
-    /**
-     * converts a UnscaledValue_t to a BigDecimal
-     * @param value
-     */
-    constexpr explicit BigDecimal(const UnscaledValue_t &value) noexcept
-        requires(!std::is_same_v<UnscaledValue_t, int32_t> && !std::is_same_v<UnscaledValue_t, int64_t>)
-        : BigDecimal(value, 0) {}
-
-    /**
-     * converts a float to a BigDecimal.
-     * this conversion might not be exact, due to the built in limitations of floats.
-     * if you have the possibility, use one of the other constructors.
-     * @param value
-     * @throw std::overflow_error on exceeding the types numeric limits
-     */
-    constexpr explicit BigDecimal(float value) : BigDecimal(static_cast<double>(value)) {}
-
-private:
-    void from_double_direct(double value)
-    requires(std::numeric_limits<UnscaledValue_t>::digits >= std::numeric_limits<boost::multiprecision::int1024_t>::digits)
-    {
-        // most of the algorithm is from OpenJDK: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/classes/java/math/BigDecimal.java#L915
-        if (std::isinf(value) || std::isnan(value))
-            throw std::invalid_argument{"value is NaN or infinity"};
-        // this might fail on anything that is not x86-32/64
-        static_assert(std::endian::native == std::endian::little, "BigDecimal{double} is only tested on x86-32/64 and might not work on other systems");
-        // double is an IEEE 754 64-bit floating point value
-        // memory layout:
-        // sign | exponent  | fraction
-        // 63   | 62 ... 52 | 51 ... 0
-        // see https://en.wikipedia.org/wiki/Double-precision_floating-point_format for more info (and a better graphic)
-        auto v = std::bit_cast<uint64_t>(value);
-        bool const neg = (v >> 63) != 0;
-        auto ex = static_cast<int>((v >> 52) & 0x7ffL);
-        uint64_t significand = ex == 0
-                                       ? (v & ((1L << 52) - 1)) << 1
-                                       : (v & ((1L << 52) - 1)) | (1L << 52);
-        ex -= 1075;
-        if (significand == 0) {
-            return;
-        }
-        while ((significand & 1) == 0) {
-            significand >>= 1;
-            ++ex;
-        }
-        static constexpr const char *exc = "double to BigDecimal overflow";
-        if (ex == 0) {
-            unscaled_value = UnscaledValue_t{significand};
-        } else if (ex < 0) {
-            exponent = static_cast<Exponent_t>(-ex);
-            UnscaledValue_t e{0};
-            if (util::detail::pow_checked<OverflowMode::Checked>(UnscaledValue_t{5}, -ex, e))
-                throw std::overflow_error{exc};
-            if (util::detail::mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
-                throw std::overflow_error{exc};
-        } else {
-            UnscaledValue_t e{0};
-            if (util::detail::pow_checked<OverflowMode::Checked>(UnscaledValue_t{2}, ex, e))
-                throw std::overflow_error{exc};
-            if (util::detail::mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
-                throw std::overflow_error{exc};
-        }
-        if (neg)
-            unscaled_value = -unscaled_value;
-        normalize();
-    }
-
-public:
-    /**
-     * converts a double to a BigDecimal.
-     * this conversion might not be exact, due to the built in limitations of doubles.
-     * if you have the possibility, use one of the other constructors.
-     * @param value
-     * @throw std::overflow_error on exceeding the types numeric limits
-     */
-    explicit BigDecimal(double value) : unscaled_value(0), exponent(0) {
-        if constexpr (!std::numeric_limits<UnscaledValue_t>::is_bounded) {
-            from_double_direct(value);
-        } else {
-            BigDecimal<boost::multiprecision::checked_cpp_int> v{value};
-            while (true) {
-                if (util::detail::cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value) || util::detail::cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent)) {
-                    if (v.get_exponent() > 0) {
-                        v = {v.get_unscaled_value() / base, v.get_exponent() - 1};
+            /**
+             * parses a BigDecimal from a string_view.
+             * may include a leading sign and one decimal point ., everything else needs to be numeric.
+             * @param value
+             * @throw rdf4cpp::InvalidNode if a invalid char is found, or on exceeding the types numeric limits
+             */
+            constexpr explicit BigDecimal(std::string_view value) : unscaled_value(0), exponent(0) {
+                bool begin = true;
+                bool decimal = false;
+                bool neg = false;
+                for (char const c : value) {
+                    if (begin) {
+                        begin = false;
+                        if (c == '-') {
+                            neg = true;
+                            continue;
+                        } else if (c == '+') {
+                            continue;
+                        }
+                    }
+                    if (c == '.') {
+                        if (decimal) {
+                            throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: more than one . found"};
+                        }
+                        decimal = true;
                         continue;
                     }
-                    throw std::overflow_error{"double -> decimal unscaled value overflow"};
+                    if (c < '0' || c > '9') {
+                        throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: non-numeric char found"};
+                    }
+                    auto n = c - '0';
+                    if (detail::mul_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{base}, unscaled_value)) {
+                        throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: unscaled_value overflow"};
+                    }
+                    if (detail::add_checked<OverflowMode::Checked>(unscaled_value, UnscaledValue_t{n}, unscaled_value)) {
+                        throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: unscaled_value overflow"};
+                    }
+                    if (decimal) {
+                        if (detail::add_checked<OverflowMode::Checked>(exponent, Exponent_t{1}, exponent)) {
+                            throw InvalidNode{"http://www.w3.org/2001/XMLSchema#decimal parsing error: exponent overflow"};
+                        }
+                    }
                 }
-                return;
+                if (unscaled_value == 0) {
+                    neg = false;
+                }
+                if (neg) {
+                    unscaled_value = -unscaled_value;
+                }
             }
-        }
-    }
 
-    /**
-     * converts this BigDecimal to its smallest internal representation.
-     */
-    constexpr void normalize() noexcept {
-        normalize(unscaled_value, exponent);
-    }
+            /**
+             * converts a uint32_t to a BigDecimal
+             * @param value
+             */
+            constexpr explicit BigDecimal(uint32_t value) noexcept : BigDecimal(UnscaledValue_t{value}, 0) {
+            }
 
-    /**
-     * converts this BigDecimal to its smallest internal representation.
-     */
-    static constexpr void normalize(UnscaledValue_t &unscaled_value, Exponent_t &exponent) noexcept {
-        while (exponent > 0 && unscaled_value % base == 0) {
-            unscaled_value /= base;
-            --exponent;
-        }
-    }
+            /**
+             * converts a uint64_t to a BigDecimal
+             * @param value
+             */
+            constexpr explicit BigDecimal(uint64_t value) noexcept : BigDecimal(UnscaledValue_t{value}, 0) {
+            }
 
-    [[nodiscard]] constexpr Exponent_t get_exponent() const noexcept {
-        return exponent;
-    }
+            /**
+             * converts a int32_t to a BigDecimal
+             * @param value
+             */
+            constexpr explicit BigDecimal(int32_t value) noexcept : BigDecimal(static_cast<UnscaledValue_t>(value), 0) {
+            }
 
-    [[nodiscard]] constexpr UnscaledValue_t get_unscaled_value() const noexcept {
-        return unscaled_value;
-    }
+            /**
+             * converts a int64_t to a BigDecimal
+             * @param value
+             */
+            constexpr explicit BigDecimal(int64_t value) noexcept : BigDecimal(static_cast<UnscaledValue_t>(value), 0) {
+            }
 
-    [[nodiscard]] constexpr bool positive() const noexcept {
-        return unscaled_value >= 0;
-    }
+            /**
+             * converts a UnscaledValue_t to a BigDecimal
+             * @param value
+             */
+            constexpr explicit BigDecimal(UnscaledValue_t const &value) noexcept
+            requires(!std::is_same_v<UnscaledValue_t, int32_t> && !std::is_same_v<UnscaledValue_t, int64_t>)
+                : BigDecimal(value, 0) {
+            }
 
-private:
-    // op_checked has to be add_checked or sub_checked with the same OverflowMode
-    template<OverflowMode m, bool (*op_checked)(const UnscaledValue_t &t, const UnscaledValue_t &o, UnscaledValue_t &result)>
-    constexpr bool add_or_sub(const BigDecimal &other, BigDecimal &result) const noexcept {
-        UnscaledValue_t t = this->unscaled_value;
-        UnscaledValue_t o = other.unscaled_value;
-        Exponent_t new_exp = std::max(this->exponent, other.exponent);
-        if (this->exponent < new_exp) {
-            UnscaledValue_t ex{0};
-            if (util::detail::pow_checked<m>(UnscaledValue_t{base}, new_exp - this->exponent, ex))
-                return true;
-            if (util::detail::mul_checked<m>(t, ex, t))
-                return true;
-        } else if (other.exponent < new_exp) {
-            UnscaledValue_t ex{0};
-            if (util::detail::pow_checked<m>(UnscaledValue_t{base}, new_exp - other.exponent, ex))
-                return true;
-            if (util::detail::mul_checked<m>(o, ex, o))
-                return true;
-        }
-        UnscaledValue_t res = 0;
-        if (op_checked(t, o, res))
-            return true;
-        result = BigDecimal{res, new_exp};
-        return false;
-    }
+            /**
+             * converts a float to a BigDecimal.
+             * this conversion might not be exact, due to the built in limitations of floats.
+             * if you have the possibility, use one of the other constructors.
+             * @param value
+             * @throw std::overflow_error on exceeding the types numeric limits
+             */
+            constexpr explicit BigDecimal(float value) : BigDecimal(static_cast<double>(value)) {
+            }
 
-    template<OverflowMode m>
-    constexpr bool mul(const BigDecimal &other, BigDecimal &result) const noexcept {
-        UnscaledValue_t v{0};
-        if (util::detail::mul_checked<m>(this->unscaled_value, other.unscaled_value, v))
-            return true;
-        Exponent_t e{0};
-        if (util::detail::add_checked<m>(this->exponent, other.exponent, e))
-            return true;
-        result = BigDecimal{v, e};
-        return false;
-    }
-
-    constexpr static BigDecimal handle_rounding(UnscaledValue_t v, Exponent_t e, UnscaledValue_t rem, RoundingMode m) noexcept {
-        switch (m) {
-            case RoundingMode::Trunc:
-                return BigDecimal{v, e};
-            case RoundingMode::Floor:
-                if (v >= 0 || rem == 0)
-                    return BigDecimal{v, e};
-                else
-                    return BigDecimal{v - 1, e};
-            case RoundingMode::Ceil:
-                if (v < 0 || rem == 0)
-                    return BigDecimal{v, e};
-                else
-                    return BigDecimal{v + 1, e};
-            case RoundingMode::Round:
-                if (rem < 0)
-                    rem = -rem;
-                if (v < 0) {
-                    if (rem >= 5)
-                        return BigDecimal{v - 1, e};
-                    else
-                        return BigDecimal{v, e};
-                } else {
-                    if (rem >= 5)
-                        return BigDecimal{v + 1, e};
-                    else
-                        return BigDecimal{v, e};
+        private:
+            void from_double_direct(double value)
+            requires(std::numeric_limits<UnscaledValue_t>::digits >= std::numeric_limits<boost::multiprecision::int1024_t>::digits)
+            {
+                // most of the algorithm is from OpenJDK: https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/classes/java/math/BigDecimal.java#L915
+                if (std::isinf(value) || std::isnan(value))
+                    throw std::invalid_argument{"value is NaN or infinity"};
+                // this might fail on anything that is not x86-32/64
+                static_assert(std::endian::native == std::endian::little, "BigDecimal{double} is only tested on x86-32/64 and might not work on other systems");
+                // double is an IEEE 754 64-bit floating point value
+                // memory layout:
+                // sign | exponent  | fraction
+                // 63   | 62 ... 52 | 51 ... 0
+                // see https://en.wikipedia.org/wiki/Double-precision_floating-point_format for more info (and a better graphic)
+                auto v = std::bit_cast<uint64_t>(value);
+                bool const neg = (v >> 63) != 0;
+                auto ex = static_cast<int>((v >> 52) & 0x7ffL);
+                uint64_t significand = ex == 0
+                                               ? (v & ((1L << 52) - 1)) << 1
+                                               : (v & ((1L << 52) - 1)) | (1L << 52);
+                ex -= 1075;
+                if (significand == 0) {
+                    return;
                 }
-            default:
-                assert(false);
-                __builtin_unreachable();
-        }
-    }
+                while ((significand & 1) == 0) {
+                    significand >>= 1;
+                    ++ex;
+                }
+                static constexpr char const *exc = "double to BigDecimal overflow";
+                if (ex == 0) {
+                    unscaled_value = UnscaledValue_t{significand};
+                } else if (ex < 0) {
+                    exponent = static_cast<Exponent_t>(-ex);
+                    UnscaledValue_t e{0};
+                    if (detail::pow_checked<OverflowMode::Checked>(UnscaledValue_t{5}, -ex, e))
+                        throw std::overflow_error{exc};
+                    if (detail::mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
+                        throw std::overflow_error{exc};
+                } else {
+                    UnscaledValue_t e{0};
+                    if (detail::pow_checked<OverflowMode::Checked>(UnscaledValue_t{2}, ex, e))
+                        throw std::overflow_error{exc};
+                    if (detail::mul_checked<OverflowMode::Checked>(UnscaledValue_t{significand}, e, unscaled_value))
+                        throw std::overflow_error{exc};
+                }
+                if (neg)
+                    unscaled_value = -unscaled_value;
+                normalize();
+            }
 
-    template<OverflowMode m>
-    constexpr bool div(const BigDecimal &other, Exponent_t max_scale_increase, RoundingMode mode, BigDecimal &result) const noexcept {
-        if (this->unscaled_value == 0) {
-            result = BigDecimal{0, 0};
-            return false;
-        }
-        UnscaledValue_t t = this->unscaled_value;
-        Exponent_t ex = this->exponent;
-        UnscaledValue_t div = other.unscaled_value;
-        if (ex >= other.exponent) {
-            if (util::detail::sub_checked<m>(ex, other.exponent, ex))
-                return true;
-        } else {
-            Exponent_t tmp{0};
-            if (util::detail::sub_checked<m>(other.exponent, ex, tmp))
-                return true;
-            if (util::detail::pow_checked<m>(Exponent_t{base}, tmp, tmp))
-                return true;
-            UnscaledValue_t tmp2{0};
-            if (util::detail::cast_checked<m>(tmp, tmp2))
-                return true;
-            if (util::detail::mul_checked<m>(t, tmp2, t))
-                return true;
-            ex = 0;
-        }
-        UnscaledValue_t res = t / div;
-        UnscaledValue_t rem = t % div;
-        while (rem != 0) {
-            if (max_scale_increase == 0) {
-                if (util::detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+        public:
+            /**
+             * converts a double to a BigDecimal.
+             * this conversion might not be exact, due to the built in limitations of doubles.
+             * if you have the possibility, use one of the other constructors.
+             * @param value
+             * @throw std::overflow_error on exceeding the types numeric limits
+             */
+            explicit BigDecimal(double value) : unscaled_value(0), exponent(0) {
+                if constexpr (!std::numeric_limits<UnscaledValue_t>::is_bounded) {
+                    from_double_direct(value);
+                } else {
+                    BigDecimal<boost::multiprecision::checked_cpp_int> v{value};
+                    while (true) {
+                        if (detail::cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value) || detail::cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent)) {
+                            if (v.get_exponent() > 0) {
+                                v = BigDecimal<boost::multiprecision::checked_cpp_int>{v.get_unscaled_value() / base, v.get_exponent() - 1};
+                                continue;
+                            }
+                            throw std::overflow_error{"double -> decimal unscaled value overflow"};
+                        }
+                        return;
+                    }
+                }
+            }
+
+            /**
+             * converts this BigDecimal to its smallest internal representation.
+             */
+            constexpr void normalize() noexcept {
+                normalize(unscaled_value, exponent);
+            }
+
+            /**
+             * converts this BigDecimal to its smallest internal representation.
+             */
+            static constexpr void normalize(UnscaledValue_t &unscaled_value, Exponent_t &exponent) noexcept {
+                while (exponent > 0 && unscaled_value % base == 0) {
+                    unscaled_value /= base;
+                    --exponent;
+                }
+            }
+
+            [[nodiscard]] constexpr Exponent_t get_exponent() const noexcept {
+                return exponent;
+            }
+
+            [[nodiscard]] constexpr UnscaledValue_t get_unscaled_value() const noexcept {
+                return unscaled_value;
+            }
+
+            [[nodiscard]] constexpr bool positive() const noexcept {
+                return unscaled_value >= 0;
+            }
+
+        private:
+            // op_checked has to be add_checked or sub_checked with the same OverflowMode
+            template<OverflowMode m, bool (*op_checked)(UnscaledValue_t const &t, UnscaledValue_t const &o, UnscaledValue_t &result)>
+            constexpr bool add_or_sub(BigDecimal const &other, BigDecimal &result) const noexcept {
+                UnscaledValue_t t = this->unscaled_value;
+                UnscaledValue_t o = other.unscaled_value;
+                Exponent_t new_exp = std::max(this->exponent, other.exponent);
+                if (this->exponent < new_exp) {
+                    UnscaledValue_t ex{0};
+                    if (detail::pow_checked<m>(UnscaledValue_t{base}, new_exp - this->exponent, ex))
+                        return true;
+                    if (detail::mul_checked<m>(t, ex, t))
+                        return true;
+                } else if (other.exponent < new_exp) {
+                    UnscaledValue_t ex{0};
+                    if (detail::pow_checked<m>(UnscaledValue_t{base}, new_exp - other.exponent, ex))
+                        return true;
+                    if (detail::mul_checked<m>(o, ex, o))
+                        return true;
+                }
+                UnscaledValue_t res = 0;
+                if (op_checked(t, o, res))
                     return true;
-                result = handle_rounding(res, ex, rem / div, mode);
+                result = BigDecimal{res, new_exp};
                 return false;
             }
-            if constexpr (std::is_integral_v<Exponent_t>) {
-                if (ex == std::numeric_limits<Exponent_t>::max()) {
-                    if (util::detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
-                        return true;
-                    result = handle_rounding(res, ex, rem / div, mode);
+
+            template<OverflowMode m>
+            constexpr bool mul(BigDecimal const &other, BigDecimal &result) const noexcept {
+                UnscaledValue_t v{0};
+                if (detail::mul_checked<m>(this->unscaled_value, other.unscaled_value, v))
+                    return true;
+                Exponent_t e{0};
+                if (detail::add_checked<m>(this->exponent, other.exponent, e))
+                    return true;
+                result = BigDecimal{v, e};
+                return false;
+            }
+
+            static constexpr BigDecimal handle_rounding(UnscaledValue_t v, Exponent_t e, UnscaledValue_t rem, RoundingMode m) noexcept {
+                switch (m) {
+                    case RoundingMode::Trunc:
+                        return BigDecimal{v, e};
+                    case RoundingMode::Floor:
+                        if (v >= 0 || rem == 0)
+                            return BigDecimal{v, e};
+                        else
+                            return BigDecimal{v - 1, e};
+                    case RoundingMode::Ceil:
+                        if (v < 0 || rem == 0)
+                            return BigDecimal{v, e};
+                        else
+                            return BigDecimal{v + 1, e};
+                    case RoundingMode::Round:
+                        if (rem < 0)
+                            rem = -rem;
+                        if (v < 0) {
+                            if (rem >= 5)
+                                return BigDecimal{v - 1, e};
+                            else
+                                return BigDecimal{v, e};
+                        } else {
+                            if (rem >= 5)
+                                return BigDecimal{v + 1, e};
+                            else
+                                return BigDecimal{v, e};
+                        }
+                    default:
+                        assert(false);
+                        __builtin_unreachable();
+                }
+            }
+
+            template<OverflowMode m>
+            constexpr bool div(BigDecimal const &other, Exponent_t max_scale_increase, RoundingMode mode, BigDecimal &result) const noexcept {
+                if (this->unscaled_value == 0) {
+                    result = BigDecimal{0, 0};
                     return false;
                 }
+                UnscaledValue_t t = this->unscaled_value;
+                Exponent_t ex = this->exponent;
+                UnscaledValue_t div = other.unscaled_value;
+                if (ex >= other.exponent) {
+                    if (detail::sub_checked<m>(ex, other.exponent, ex))
+                        return true;
+                } else {
+                    Exponent_t tmp{0};
+                    if (detail::sub_checked<m>(other.exponent, ex, tmp))
+                        return true;
+                    if (detail::pow_checked<m>(Exponent_t{base}, tmp, tmp))
+                        return true;
+                    UnscaledValue_t tmp2{0};
+                    if (detail::cast_checked<m>(tmp, tmp2))
+                        return true;
+                    if (detail::mul_checked<m>(t, tmp2, t))
+                        return true;
+                    ex = 0;
+                }
+                UnscaledValue_t res = t / div;
+                UnscaledValue_t rem = t % div;
+                while (rem != 0) {
+                    if (max_scale_increase == 0) {
+                        if (detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+                            return true;
+                        result = handle_rounding(res, ex, rem / div, mode);
+                        return false;
+                    }
+                    if constexpr (std::is_integral_v<Exponent_t>) {
+                        if (ex == std::numeric_limits<Exponent_t>::max()) {
+                            if (detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+                                return true;
+                            result = handle_rounding(res, ex, rem / div, mode);
+                            return false;
+                        }
+                    }
+                    ++ex;
+                    if (detail::mul_checked<m>(res, UnscaledValue_t{base}, res))
+                        return true;
+                    if (detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
+                        return true;
+                    res += rem / div;
+                    rem = rem % div;
+                    --max_scale_increase;
+                }
+                result = BigDecimal{res, ex};
+                return false;
             }
-            ++ex;
-            if (util::detail::mul_checked<m>(res, UnscaledValue_t{base}, res))
-                return true;
-            if (util::detail::mul_checked<m>(rem, UnscaledValue_t{base}, rem))
-                return true;
-            res += rem / div;
-            rem = rem % div;
-            --max_scale_increase;
-        }
-        result = BigDecimal{res, ex};
-        return false;
-    }
 
-    template<OverflowMode m>
-    constexpr bool pow(unsigned int n, BigDecimal &result) const noexcept {
-        BigDecimal r{1};
+            template<OverflowMode m>
+            constexpr bool pow(unsigned int n, BigDecimal &result) const noexcept {
+                BigDecimal r{1};
 
-        for (unsigned int i = 0; i < n; ++i) {
-            if (r.mul<m>(*this, r))
-                return true;
-        }
-        result = r;
-        return false;
-    }
+                for (unsigned int i = 0; i < n; ++i) {
+                    if (r.mul<m>(*this, r))
+                        return true;
+                }
+                result = r;
+                return false;
+            }
 
-    static double cast_unscaled_to_double_safe(UnscaledValue_t const &value) noexcept {
-        // There is a bug in boost versions <1.86.0
-        // that can cause a crash in the cast `static_cast<double>(cpp_int)`
-        // https://github.com/boostorg/multiprecision/issues/553
+            static double cast_unscaled_to_double_safe(UnscaledValue_t const &value) noexcept {
+                // There is a bug in boost versions <1.86.0
+                // that can cause a crash in the cast `static_cast<double>(cpp_int)`
+                // https://github.com/boostorg/multiprecision/issues/553
 
 #if BOOST_VERSION < 108600
-        // workaround from https://github.com/scylladb/scylladb/commit/51d09e6a2a407ea9b9ad380ba30e5558a25bb8be#diff-81e6758bbedbe566a51706c5af1ea68be225c36feb68983c3de0a69138f01264R73
-        static auto const min = UnscaledValue_t{std::numeric_limits<double>::lowest()};
-        static auto const max = UnscaledValue_t{std::numeric_limits<double>::max()};
-        if (value < min) {
-            return -std::numeric_limits<double>::infinity();
-        } else if (value > max) {
-            return std::numeric_limits<double>::infinity();
-        }
-#endif // BOOST_VERSION
-
-        return static_cast<double>(value);
-    }
-
-public:
-    /**
-     * unary minus of this BigDecimal.
-     * may overflow.
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal operator-() const noexcept {
-        return BigDecimal(-this->unscaled_value, this->exponent);
-    }
-    /**
-     * unary minus of this BigDecimal.
-     * checks overflow.
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> unary_minus_checked() const noexcept {
-        if constexpr (std::is_integral_v<UnscaledValue_t>) {
-            if (std::numeric_limits<UnscaledValue_t>::min() == unscaled_value)
-                return nonstd::make_unexpected(DecimalError::Overflow);
-        }
-        return BigDecimal(-this->unscaled_value, this->exponent);
-    }
-
-
-    /**
-     * unary plus (nop) of this BigDecimal.
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal operator+() const noexcept {
-        return *this;
-    }
-
-    /**
-     * addition of two BigDecimals.
-     * may overflow.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal operator+(const BigDecimal &other) const noexcept {
-        BigDecimal res{0};
-        add_or_sub<OverflowMode::UndefinedBehavior, util::detail::add_checked<OverflowMode::UndefinedBehavior>>(other, res);
-        return res;
-    }
-    /**
-     * addition of two BigDecimals.
-     * checks overflow.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> add_checked(const BigDecimal &other) const noexcept {
-        BigDecimal res{0};
-        if (add_or_sub<OverflowMode::Checked, util::detail::add_checked<OverflowMode::Checked>>(other, res))
-            return nonstd::make_unexpected(DecimalError::Overflow);
-        return res;
-    }
-
-    /**
-     * addition of two BigDecimals.
-     * may overflow.
-     * @param other
-     * @return
-     */
-    constexpr BigDecimal &operator+=(const BigDecimal &other) noexcept {
-        *this = *this + other;
-        return *this;
-    }
-
-    /**
-     * subtraction of two BigDecimals.
-     * may overflow.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal operator-(const BigDecimal &other) const noexcept {
-        BigDecimal res{0};
-        add_or_sub<OverflowMode::UndefinedBehavior, util::detail::sub_checked<OverflowMode::UndefinedBehavior>>(other, res);
-        return res;
-    }
-
-    /**
-     * subtraction of two BigDecimals.
-     * checks overflow.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> sub_checked(const BigDecimal &other) const noexcept {
-        BigDecimal res{0};
-        if (add_or_sub<OverflowMode::Checked, util::detail::sub_checked<OverflowMode::Checked>>(other, res))
-            return nonstd::make_unexpected(DecimalError::Overflow);
-        return res;
-    }
-
-    /**
-     * subtraction of two BigDecimals.
-     * may overflow.
-     * @param other
-     * @return
-     */
-    constexpr BigDecimal operator-=(const BigDecimal &other) noexcept {
-        *this = *this - other;
-        return *this;
-    }
-
-    /**
-     * multiplication of two BigDecimals.
-     * may overflow.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal operator*(const BigDecimal &other) const noexcept {
-        BigDecimal res{0};
-        mul<OverflowMode::UndefinedBehavior>(other, res);
-        return res;
-    }
-
-    /**
-     * multiplication of two BigDecimals.
-     * checks overflow.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> mul_checked(const BigDecimal &other) const noexcept {
-        BigDecimal res{0};
-        if (mul<OverflowMode::Checked>(other, res))
-            return nonstd::make_unexpected(DecimalError::Overflow);
-        return res;
-    }
-
-    /**
-     * multiplication of two BigDecimals.
-     * may overflow.
-     * @param other
-     * @return
-     */
-    constexpr BigDecimal &operator*=(const BigDecimal &other) noexcept {
-        *this = *this * other;
-        return *this;
-    }
-
-    /**
-     * default value for scale increase when using operators.
-     * when this many decimal places have been added, stop dividing and floor.
-     */
-    static constexpr Exponent_t default_max_scale_increase = 20;
-
-    /**
-     * division of two BigDecimals.
-     * may overflow.
-     * after default_max_scale_increase decimal places have been added, stops dividing and floor.
-     * dividing by 0 is undefined behavior.
-     * @param other
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal operator/(const BigDecimal &other) const noexcept {
-        return div(other, default_max_scale_increase);
-    }
-
-    /**
-     * division of two BigDecimals.
-     * may overflow.
-     * dividing by 0 is undefined behavior.
-     * @param other
-     * @param max_scale_increase after this many decimal places have been added, stop dividing and round
-     * @param mode rounding mode to use
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal div(const BigDecimal &other, Exponent_t max_scale_increase, RoundingMode mode = RoundingMode::Floor) const noexcept {
-        if (other.unscaled_value == 0)
-            return BigDecimal{0, 0};  // undefined behavior (cpp_int throws)
-        BigDecimal res{0};
-        div<OverflowMode::UndefinedBehavior>(other, max_scale_increase, mode, res);
-        return res;
-    }
-
-    /**
-     * division of two BigDecimals.
-     * checks overflow and division by 0.
-     * @param other
-     * @param max_scale_increase after this many decimal places have been added, stop dividing and round
-     * @param mode rounding mode to use
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> div_checked(const BigDecimal &other, Exponent_t max_scale_increase, RoundingMode mode = RoundingMode::Floor) const noexcept {
-        if (other.unscaled_value == 0)
-            return nonstd::make_unexpected(DecimalError::NotDefined);
-        BigDecimal res{0};
-        if (div<OverflowMode::Checked>(other, max_scale_increase, mode, res))
-            return nonstd::make_unexpected(DecimalError::Overflow);
-        return res;
-    }
-
-    /**
-     * division of two BigDecimals.
-     * may overflow.
-     * after 1000 decimal places have been added, stops dividing and floor.
-     * dividing by 0 is undefined behavior.
-     * @param other
-     * @return
-     */
-    constexpr BigDecimal &operator/=(const BigDecimal &other) noexcept {
-        *this = *this / other;
-        return *this;
-    }
-
-    /**
-     * raises a BigDecimal to the power of a int.
-     * may overflow.
-     * @param n
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal pow(unsigned int n) const noexcept {
-        BigDecimal r{0};
-        pow<OverflowMode::UndefinedBehavior>(n, r);
-        return r;
-    }
-
-    /**
-     * raises a BigDecimal to the power of a int.
-     * checks overflow.
-     * @param n
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> pow_checked(unsigned int n) const noexcept {
-        BigDecimal r{0};
-        if (pow<OverflowMode::Checked>(n, r))
-            return nonstd::make_unexpected(DecimalError::Overflow);
-        return r;
-    }
-
-    /**
-     * rounds a BigDecimal with a specified RoundingMode.
-     * @param mode
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal round(RoundingMode mode) const noexcept {
-        if (exponent == 0) {
-            return *this;
-        }
-        UnscaledValue_t v{base};
-        UnscaledValue_t uns = unscaled_value;
-        if (util::detail::pow_checked<OverflowMode::Checked>(v, exponent, v)) {
-            v = {base};
-            uns /= 100;
-            if (util::detail::pow_checked<OverflowMode::Checked>(v, exponent - 2, v)) {
-                // base pow exponent overflows and this did not, we have to be close to 0
-                return BigDecimal{0, 0};
-            }
-        }
-        UnscaledValue_t rem = uns % v;
-        rem = rem / (v / base); // in rare cases, rem * 10 / v can overflow
-        v = uns / v;
-        return handle_rounding(v, 0, rem, mode);
-    }
-
-    /**
-     * the absolute value of a BigDecimal.
-     * may overflow.
-     * @return
-     */
-    [[nodiscard]] constexpr BigDecimal abs() const noexcept {
-        if (positive())
-            return *this;
-        else
-            return -*this;
-    }
-
-    /**
-     * the absolute value of a BigDecimal.
-     * checks overflow.
-     * @return
-     */
-    [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> abs_checked() const noexcept {
-        if (positive())
-            return *this;
-        else
-            return this->unary_minus_checked();
-    }
-
-    /**
-     * comparison between BigDecimals.
-     * @param other
-     * @return
-     */
-    constexpr std::strong_ordering operator<=>(const BigDecimal &other) const noexcept {
-        if (this->positive() != other.positive())
-            return this->positive() ? std::strong_ordering::greater : std::strong_ordering::less;
-        UnscaledValue_t t = this->unscaled_value;
-        UnscaledValue_t o = other.unscaled_value;
-        // scale both values to have the same exponent
-        // if one of the decimals is 0, skip and compare directly (0*base^e is 0 for all e)
-        if (t != 0 && o != 0) {
-            if (this->exponent > other.exponent) {
-                UnscaledValue_t b{base};
-                if (util::detail::pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))
-                    return std::strong_ordering::less;  // t does fit into the same precision, while o does not
-                if (util::detail::mul_checked<OverflowMode::Checked>(o, b, o))
-                    return std::strong_ordering::less;  // t does fit into the same precision, while o does not
-            } else if (this->exponent < other.exponent) {
-                UnscaledValue_t b{base};
-                if (util::detail::pow_checked<OverflowMode::Checked>(b, other.exponent - this->exponent, b))
-                    return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
-                if (util::detail::mul_checked<OverflowMode::Checked>(t, b, t))
-                    return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
-            }
-        }
-        if (t < o)
-            return std::strong_ordering::less;
-        else if (t > o)
-            return std::strong_ordering::greater;
-        else
-            return std::strong_ordering::equivalent;
-    };
-    /**
-     * equality between BigDecimals.
-     * @param other
-     * @return
-     */
-    constexpr bool operator==(const BigDecimal &other) const noexcept {
-        return *this <=> other == std::strong_ordering::equivalent;
-    }
-    /**
-     * equality between a BigDecimal and a int (mainly for constants)
-     * @param t
-     * @param other
-     * @return
-     */
-    friend bool operator==(const BigDecimal &t, int other) noexcept {
-        return t == BigDecimal{other, 0};
-    }
-    /**
-     * equality between a BigDecimal and a int (mainly for constants)
-     * @param t
-     * @param other
-     * @return
-     */
-    friend bool operator==(int t, const BigDecimal &other) noexcept {
-        return other == t;
-    }
-
-    /**
-     * conversion to a double
-     * @return
-     */
-    [[nodiscard]] explicit operator double() const noexcept {
-        double const v = cast_unscaled_to_double_safe(unscaled_value) * std::pow(static_cast<double>(base), -static_cast<double>(exponent));
-        if (!std::isnan(v) && !std::isinf(v))
-            return v;
-        // even Javas BigDecimal has no better solution
-        auto const s = static_cast<std::string>(*this);
-        return std::stod(s);
-    }
-
-    /**
-     * conversion to a float
-     * @return
-     */
-    [[nodiscard]] explicit operator float() const noexcept {
-        return static_cast<float>(static_cast<double>(*this));
-    }
-
-    /**
-     * conversion to a UnscaledValue_t
-     * @return
-     */
-    [[nodiscard]] constexpr explicit operator UnscaledValue_t() const noexcept {
-        if (exponent == 0)
-            return unscaled_value;
-        return round(RoundingMode::Trunc).unscaled_value;
-    }
-
-    /**
-     * conversion to a string
-     * @return
-     */
-    [[nodiscard]] explicit operator std::string() const noexcept {
-        if (unscaled_value == 0)
-            return "0.0";
-        std::stringstream s{};
-        UnscaledValue_t v = unscaled_value;
-        Exponent_t ex = exponent;
-        bool hasDot = false;
-        while (v != 0) {
-            if (!hasDot && ex == 0) {
-                if (s.view().empty()) {
-                    s << '0';
+                // workaround from https://github.com/scylladb/scylladb/commit/51d09e6a2a407ea9b9ad380ba30e5558a25bb8be#diff-81e6758bbedbe566a51706c5af1ea68be225c36feb68983c3de0a69138f01264R73
+                static auto const min = UnscaledValue_t{std::numeric_limits<double>::lowest()};
+                static auto const max = UnscaledValue_t{std::numeric_limits<double>::max()};
+                if (value < min) {
+                    return -std::numeric_limits<double>::infinity();
+                } else if (value > max) {
+                    return std::numeric_limits<double>::infinity();
                 }
-                s << '.';
-                hasDot = true;
-            } else {
-                --ex;
+#endif  // BOOST_VERSION
+
+                return static_cast<double>(value);
             }
-            using namespace std;
-            auto c = static_cast<uint32_t>(abs(v % base));
-            if (hasDot || c != 0 || !s.view().empty()) {  // skip trailing 0s
-                s << c;
+
+        public:
+            /**
+             * unary minus of this BigDecimal.
+             * may overflow.
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal operator-() const noexcept {
+                return BigDecimal(-this->unscaled_value, this->exponent);
             }
-            v /= base;
-        }
-        if (!hasDot) {
-            for (Exponent_t i = 0; i < ex; ++i) {
-                s << '0';
+            /**
+             * unary minus of this BigDecimal.
+             * checks overflow.
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> unary_minus_checked() const noexcept {
+                if constexpr (std::is_integral_v<UnscaledValue_t>) {
+                    if (std::numeric_limits<UnscaledValue_t>::min() == unscaled_value)
+                        return nonstd::make_unexpected(DecimalError::Overflow);
+                }
+                return BigDecimal(-this->unscaled_value, this->exponent);
             }
-            s << ".0";
+
+
+            /**
+             * unary plus (nop) of this BigDecimal.
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal operator+() const noexcept {
+                return *this;
+            }
+
+            /**
+             * addition of two BigDecimals.
+             * may overflow.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal operator+(BigDecimal const &other) const noexcept {
+                BigDecimal res{0};
+                add_or_sub<OverflowMode::UndefinedBehavior, detail::add_checked<OverflowMode::UndefinedBehavior>>(other, res);
+                return res;
+            }
+            /**
+             * addition of two BigDecimals.
+             * checks overflow.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> add_checked(BigDecimal const &other) const noexcept {
+                BigDecimal res{0};
+                if (add_or_sub<OverflowMode::Checked, detail::add_checked<OverflowMode::Checked>>(other, res))
+                    return nonstd::make_unexpected(DecimalError::Overflow);
+                return res;
+            }
+
+            /**
+             * addition of two BigDecimals.
+             * may overflow.
+             * @param other
+             * @return
+             */
+            constexpr BigDecimal &operator+=(BigDecimal const &other) noexcept {
+                *this = *this + other;
+                return *this;
+            }
+
+            /**
+             * subtraction of two BigDecimals.
+             * may overflow.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal operator-(BigDecimal const &other) const noexcept {
+                BigDecimal res{0};
+                add_or_sub<OverflowMode::UndefinedBehavior, detail::sub_checked<OverflowMode::UndefinedBehavior>>(other, res);
+                return res;
+            }
+
+            /**
+             * subtraction of two BigDecimals.
+             * checks overflow.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> sub_checked(BigDecimal const &other) const noexcept {
+                BigDecimal res{0};
+                if (add_or_sub<OverflowMode::Checked, detail::sub_checked<OverflowMode::Checked>>(other, res))
+                    return nonstd::make_unexpected(DecimalError::Overflow);
+                return res;
+            }
+
+            /**
+             * subtraction of two BigDecimals.
+             * may overflow.
+             * @param other
+             * @return
+             */
+            constexpr BigDecimal operator-=(BigDecimal const &other) noexcept {
+                *this = *this - other;
+                return *this;
+            }
+
+            /**
+             * multiplication of two BigDecimals.
+             * may overflow.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal operator*(BigDecimal const &other) const noexcept {
+                BigDecimal res{0};
+                mul<OverflowMode::UndefinedBehavior>(other, res);
+                return res;
+            }
+
+            /**
+             * multiplication of two BigDecimals.
+             * checks overflow.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> mul_checked(BigDecimal const &other) const noexcept {
+                BigDecimal res{0};
+                if (mul<OverflowMode::Checked>(other, res))
+                    return nonstd::make_unexpected(DecimalError::Overflow);
+                return res;
+            }
+
+            /**
+             * multiplication of two BigDecimals.
+             * may overflow.
+             * @param other
+             * @return
+             */
+            constexpr BigDecimal &operator*=(BigDecimal const &other) noexcept {
+                *this = *this * other;
+                return *this;
+            }
+
+            /**
+             * default value for scale increase when using operators.
+             * when this many decimal places have been added, stop dividing and floor.
+             */
+            static constexpr Exponent_t default_max_scale_increase = 20;
+
+            /**
+             * division of two BigDecimals.
+             * may overflow.
+             * after default_max_scale_increase decimal places have been added, stops dividing and floor.
+             * dividing by 0 is undefined behavior.
+             * @param other
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal operator/(BigDecimal const &other) const noexcept {
+                return div(other, default_max_scale_increase);
+            }
+
+            /**
+             * division of two BigDecimals.
+             * may overflow.
+             * dividing by 0 is undefined behavior.
+             * @param other
+             * @param max_scale_increase after this many decimal places have been added, stop dividing and round
+             * @param mode rounding mode to use
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal div(BigDecimal const &other, Exponent_t max_scale_increase, RoundingMode mode = RoundingMode::Floor) const noexcept {
+                if (other.unscaled_value == 0)
+                    return BigDecimal{0, 0};  // undefined behavior (cpp_int throws)
+                BigDecimal res{0};
+                div<OverflowMode::UndefinedBehavior>(other, max_scale_increase, mode, res);
+                return res;
+            }
+
+            /**
+             * division of two BigDecimals.
+             * checks overflow and division by 0.
+             * @param other
+             * @param max_scale_increase after this many decimal places have been added, stop dividing and round
+             * @param mode rounding mode to use
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> div_checked(BigDecimal const &other, Exponent_t max_scale_increase, RoundingMode mode = RoundingMode::Floor) const noexcept {
+                if (other.unscaled_value == 0)
+                    return nonstd::make_unexpected(DecimalError::NotDefined);
+                BigDecimal res{0};
+                if (div<OverflowMode::Checked>(other, max_scale_increase, mode, res))
+                    return nonstd::make_unexpected(DecimalError::Overflow);
+                return res;
+            }
+
+            /**
+             * division of two BigDecimals.
+             * may overflow.
+             * after 1000 decimal places have been added, stops dividing and floor.
+             * dividing by 0 is undefined behavior.
+             * @param other
+             * @return
+             */
+            constexpr BigDecimal &operator/=(BigDecimal const &other) noexcept {
+                *this = *this / other;
+                return *this;
+            }
+
+            /**
+             * raises a BigDecimal to the power of a int.
+             * may overflow.
+             * @param n
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal pow(unsigned int n) const noexcept {
+                BigDecimal r{0};
+                pow<OverflowMode::UndefinedBehavior>(n, r);
+                return r;
+            }
+
+            /**
+             * raises a BigDecimal to the power of a int.
+             * checks overflow.
+             * @param n
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> pow_checked(unsigned int n) const noexcept {
+                BigDecimal r{0};
+                if (pow<OverflowMode::Checked>(n, r))
+                    return nonstd::make_unexpected(DecimalError::Overflow);
+                return r;
+            }
+
+            /**
+             * rounds a BigDecimal with a specified RoundingMode.
+             * @param mode
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal round(RoundingMode mode) const noexcept {
+                if (exponent == 0) {
+                    return *this;
+                }
+                UnscaledValue_t v{base};
+                UnscaledValue_t uns = unscaled_value;
+                if (detail::pow_checked<OverflowMode::Checked>(v, exponent, v)) {
+                    v = {base};
+                    uns /= 100;
+                    if (detail::pow_checked<OverflowMode::Checked>(v, exponent - 2, v)) {
+                        // base pow exponent overflows and this did not, we have to be close to 0
+                        return BigDecimal{0, 0};
+                    }
+                }
+                UnscaledValue_t rem = uns % v;
+                rem = rem / (v / base);  // in rare cases, rem * 10 / v can overflow
+                v = uns / v;
+                return handle_rounding(v, 0, rem, mode);
+            }
+
+            /**
+             * the absolute value of a BigDecimal.
+             * may overflow.
+             * @return
+             */
+            [[nodiscard]] constexpr BigDecimal abs() const noexcept {
+                if (positive())
+                    return *this;
+                else
+                    return -*this;
+            }
+
+            /**
+             * the absolute value of a BigDecimal.
+             * checks overflow.
+             * @return
+             */
+            [[nodiscard]] constexpr nonstd::expected<BigDecimal, DecimalError> abs_checked() const noexcept {
+                if (positive())
+                    return *this;
+                else
+                    return this->unary_minus_checked();
+            }
+
+            /**
+             * comparison between BigDecimals.
+             * @param other
+             * @return
+             */
+            constexpr std::strong_ordering operator<=>(BigDecimal const &other) const noexcept {
+                if (this->positive() != other.positive())
+                    return this->positive() ? std::strong_ordering::greater : std::strong_ordering::less;
+                UnscaledValue_t t = this->unscaled_value;
+                UnscaledValue_t o = other.unscaled_value;
+                // scale both values to have the same exponent
+                // if one of the decimals is 0, skip and compare directly (0*base^e is 0 for all e)
+                if (t != 0 && o != 0) {
+                    if (this->exponent > other.exponent) {
+                        UnscaledValue_t b{base};
+                        if (detail::pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))
+                            return std::strong_ordering::less;  // t does fit into the same precision, while o does not
+                        if (detail::mul_checked<OverflowMode::Checked>(o, b, o))
+                            return std::strong_ordering::less;  // t does fit into the same precision, while o does not
+                    } else if (this->exponent < other.exponent) {
+                        UnscaledValue_t b{base};
+                        if (detail::pow_checked<OverflowMode::Checked>(b, other.exponent - this->exponent, b))
+                            return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
+                        if (detail::mul_checked<OverflowMode::Checked>(t, b, t))
+                            return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
+                    }
+                }
+                if (t < o)
+                    return std::strong_ordering::less;
+                else if (t > o)
+                    return std::strong_ordering::greater;
+                else
+                    return std::strong_ordering::equivalent;
+            };
+            /**
+             * equality between BigDecimals.
+             * @param other
+             * @return
+             */
+            constexpr bool operator==(BigDecimal const &other) const noexcept {
+                return (*this <=> other) == std::strong_ordering::equivalent;
+            }
+            /**
+             * equality between a BigDecimal and a int (mainly for constants)
+             * @param t
+             * @param other
+             * @return
+             */
+            friend bool operator==(BigDecimal const &t, int other) noexcept {
+                return t == BigDecimal{other, 0};
+            }
+            /**
+             * equality between a BigDecimal and a int (mainly for constants)
+             * @param t
+             * @param other
+             * @return
+             */
+            friend bool operator==(int t, BigDecimal const &other) noexcept {
+                return other == t;
+            }
+
+            /**
+             * conversion to a double
+             * @return
+             */
+            [[nodiscard]] explicit operator double() const noexcept {
+                double const v = cast_unscaled_to_double_safe(unscaled_value) * std::pow(static_cast<double>(base), -static_cast<double>(exponent));
+                if (!std::isnan(v) && !std::isinf(v))
+                    return v;
+                // even Javas BigDecimal has no better solution
+                auto const s = static_cast<std::string>(*this);
+                return std::stod(s);
+            }
+
+            /**
+             * conversion to a float
+             * @return
+             */
+            [[nodiscard]] explicit operator float() const noexcept {
+                return static_cast<float>(static_cast<double>(*this));
+            }
+
+            /**
+             * conversion to a UnscaledValue_t
+             * @return
+             */
+            [[nodiscard]] constexpr explicit operator UnscaledValue_t() const noexcept {
+                if (exponent == 0)
+                    return unscaled_value;
+                return round(RoundingMode::Trunc).unscaled_value;
+            }
+
+            /**
+             * conversion to a string
+             * @return
+             */
+            [[nodiscard]] explicit operator std::string() const noexcept {
+                if (unscaled_value == 0)
+                    return "0.0";
+                std::stringstream s{};
+                UnscaledValue_t v = unscaled_value;
+                Exponent_t ex = exponent;
+                bool hasDot = false;
+                while (v != 0) {
+                    if (!hasDot && ex == 0) {
+                        if (s.view().empty()) {
+                            s << '0';
+                        }
+                        s << '.';
+                        hasDot = true;
+                    } else {
+                        --ex;
+                    }
+                    using namespace std;
+                    auto c = static_cast<uint32_t>(abs(v % base));
+                    if (hasDot || c != 0 || !s.view().empty()) {  // skip trailing 0s
+                        s << c;
+                    }
+                    v /= base;
+                }
+                if (!hasDot) {
+                    for (Exponent_t i = 0; i < ex; ++i) {
+                        s << '0';
+                    }
+                    s << ".0";
+                }
+                if (!positive()) {
+                    s << '-';
+                }
+                std::string_view sv = s.view();
+                return std::string{sv.rbegin(), sv.rend()};
+            }
+
+            /**
+             * writing a BigDecimal into a stream.
+             * @param str
+             * @param bn
+             * @return
+             */
+            friend std::ostream &operator<<(std::ostream &str, BigDecimal const &bn) {
+                auto s = static_cast<std::string>(bn);
+                str << s;
+                return str;
+            }
+
+            /**
+             * combined hash of a BigDecimals components hashes.
+             * @return
+             */
+            template<dice::hash::Policies::HashPolicy Policy = dice::hash::Policies::wyhash>
+            [[nodiscard]] size_t hash() const {
+                BigDecimal n = *this;
+                n.normalize();
+
+                return dice::hash::dice_hash_templates<Policy>::dice_hash(std::tie(n.unscaled_value, n.exponent));
+            }
+        };
+
+        template<typename UnscaledValue_t, typename Exponent_t>
+        std::string to_string(BigDecimal<UnscaledValue_t, Exponent_t> const &r) noexcept {
+            return static_cast<std::string>(r);
         }
-        if (!positive()) {
-            s << '-';
+
+        template<typename UnscaledValue_t, typename Exponent_t>
+        BigDecimal<UnscaledValue_t, Exponent_t> pow(BigDecimal<UnscaledValue_t, Exponent_t> const &r, unsigned int n) noexcept {
+            return r.pow(n);
         }
-        std::string_view sv = s.view();
-        return std::string{sv.rbegin(), sv.rend()};
-    }
+        template<typename UnscaledValue_t, typename Exponent_t>
+        BigDecimal<UnscaledValue_t, Exponent_t> round(BigDecimal<UnscaledValue_t, Exponent_t> const &r) noexcept {
+            return r.round(RoundingMode::Round);
+        }
+        template<typename UnscaledValue_t, typename Exponent_t>
+        BigDecimal<UnscaledValue_t, Exponent_t> floor(BigDecimal<UnscaledValue_t, Exponent_t> const &r) noexcept {
+            return r.round(RoundingMode::Floor);
+        }
+        template<typename UnscaledValue_t, typename Exponent_t>
+        BigDecimal<UnscaledValue_t, Exponent_t> ceil(BigDecimal<UnscaledValue_t, Exponent_t> const &r) noexcept {
+            return r.round(RoundingMode::Ceil);
+        }
+        template<typename UnscaledValue_t, typename Exponent_t>
+        BigDecimal<UnscaledValue_t, Exponent_t> trunc(BigDecimal<UnscaledValue_t, Exponent_t> const &r) noexcept {
+            return r.round(RoundingMode::Trunc);
+        }
+        template<typename UnscaledValue_t, typename Exponent_t>
+        BigDecimal<UnscaledValue_t, Exponent_t> abs(BigDecimal<UnscaledValue_t, Exponent_t> const &r) noexcept {
+            return r.abs();
+        }
+    }  // namespace util
 
-    /**
-     * writing a BigDecimal into a stream.
-     * @param str
-     * @param bn
-     * @return
-     */
-    friend std::ostream &operator<<(std::ostream &str, const BigDecimal &bn) {
-        auto s = static_cast<std::string>(bn);
-        str << s;
-        return str;
-    }
-
-    /**
-     * combined hash of a BigDecimals components hashes.
-     * @return
-     */
-    template<dice::hash::Policies::HashPolicy Policy = dice::hash::Policies::wyhash>
-    [[nodiscard]] size_t hash() const {
-        BigDecimal n = *this;
-        n.normalize();
-
-        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::tie(n.unscaled_value, n.exponent));
-    }
-};
-
-template<typename UnscaledValue_t, typename Exponent_t>
-std::string to_string(const BigDecimal<UnscaledValue_t, Exponent_t> &r) noexcept {
-    return static_cast<std::string>(r);
-}
-
-template<typename UnscaledValue_t, typename Exponent_t>
-BigDecimal<UnscaledValue_t, Exponent_t> pow(const BigDecimal<UnscaledValue_t, Exponent_t> &r, unsigned int n) noexcept {
-    return r.pow(n);
-}
-template<typename UnscaledValue_t, typename Exponent_t>
-BigDecimal<UnscaledValue_t, Exponent_t> round(const BigDecimal<UnscaledValue_t, Exponent_t> &r) noexcept {
-    return r.round(RoundingMode::Round);
-}
-template<typename UnscaledValue_t, typename Exponent_t>
-BigDecimal<UnscaledValue_t, Exponent_t> floor(const BigDecimal<UnscaledValue_t, Exponent_t> &r) noexcept {
-    return r.round(RoundingMode::Floor);
-}
-template<typename UnscaledValue_t, typename Exponent_t>
-BigDecimal<UnscaledValue_t, Exponent_t> ceil(const BigDecimal<UnscaledValue_t, Exponent_t> &r) noexcept {
-    return r.round(RoundingMode::Ceil);
-}
-template<typename UnscaledValue_t, typename Exponent_t>
-BigDecimal<UnscaledValue_t, Exponent_t> trunc(const BigDecimal<UnscaledValue_t, Exponent_t> &r) noexcept {
-    return r.round(RoundingMode::Trunc);
-}
-template<typename UnscaledValue_t, typename Exponent_t>
-BigDecimal<UnscaledValue_t, Exponent_t> abs(const BigDecimal<UnscaledValue_t, Exponent_t> &r) noexcept {
-    return r.abs();
-}
+    using Decimal128 = util::BigDecimal<>;
 }  // namespace rdf4cpp
 
 #ifndef DOXYGEN_PARSER
 template<typename UnscaledValue_t, typename Exponent_t>
-struct std::hash<rdf4cpp::BigDecimal<UnscaledValue_t, Exponent_t>> {
-    size_t operator()(const rdf4cpp::BigDecimal<UnscaledValue_t, Exponent_t> &r) const {
+struct std::hash<rdf4cpp::util::BigDecimal<UnscaledValue_t, Exponent_t>> {
+    size_t operator()(rdf4cpp::util::BigDecimal<UnscaledValue_t, Exponent_t> const &r) const {
         return r.hash();
     }
 };
@@ -908,17 +920,17 @@ struct dice::hash::dice_hash_overload<Policy, ::boost::multiprecision::checked_i
 };
 
 template<typename Policy, typename U, typename E>
-struct dice::hash::dice_hash_overload<Policy, rdf4cpp::BigDecimal<U, E>> {
-    static size_t dice_hash(rdf4cpp::BigDecimal<U, E> const &x) noexcept {
+struct dice::hash::dice_hash_overload<Policy, rdf4cpp::util::BigDecimal<U, E>> {
+    static size_t dice_hash(rdf4cpp::util::BigDecimal<U, E> const &x) noexcept {
         return x.template hash<Policy>();
     }
 };
 #endif
 
 template<typename UnscaledValue_t, typename Exponent_t>
-class std::numeric_limits<rdf4cpp::BigDecimal<UnscaledValue_t, Exponent_t>> {
+class std::numeric_limits<rdf4cpp::util::BigDecimal<UnscaledValue_t, Exponent_t>> {
 public:
-    using BigDecimal = rdf4cpp::BigDecimal<UnscaledValue_t, Exponent_t>;
+    using BigDecimal = rdf4cpp::util::BigDecimal<UnscaledValue_t, Exponent_t>;
 
     static constexpr bool is_specialized = true;
     static constexpr bool is_signed = true;

--- a/src/rdf4cpp/BigDecimal.hpp
+++ b/src/rdf4cpp/BigDecimal.hpp
@@ -1,6 +1,7 @@
 #ifndef RDF4CPP_BIGDECIMAL_H
 #define RDF4CPP_BIGDECIMAL_H
 
+#include <format>
 #include <functional>
 #include <sstream>
 #include <string>
@@ -198,7 +199,7 @@ private:
         if (significand == 0) {
             return;
         }
-        while (significand & 1) {
+        while ((significand & 1) == 0) {
             significand >>= 1;
             ++ex;
         }
@@ -233,14 +234,22 @@ public:
      * @throw std::overflow_error on exceeding the types numeric limits
      */
     explicit BigDecimal(double value) : unscaled_value(0), exponent(0) {
-        if constexpr (std::numeric_limits<UnscaledValue_t>::digits >= std::numeric_limits<boost::multiprecision::int1024_t>::digits) {
+        if constexpr (!std::numeric_limits<UnscaledValue_t>::is_bounded) {
             from_double_direct(value);
         } else {
-            BigDecimal<boost::multiprecision::checked_int1024_t> const v{value};
-            if (cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value))
-                throw std::overflow_error{"double to BigDecimal overflow"};
-            if (cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent))
-                throw std::overflow_error{"double to BigDecimal overflow"};
+            BigDecimal<boost::multiprecision::checked_cpp_int> v{value};
+            while (true) {
+                if (cast_checked<OverflowMode::Checked>(v.get_unscaled_value(), unscaled_value) || cast_checked<OverflowMode::Checked>(v.get_exponent(), exponent)) {
+                    if (v.get_exponent() > 0) {
+                        v = {v.get_unscaled_value() / base, v.get_exponent() - 1};
+                        continue;
+                    }
+                    throw std::overflow_error{"double -> decimal unscaled value overflow"};
+                    //auto f = std::format("{:f}", value);
+                    //*this = BigDecimal(f);
+                }
+                return;
+            }
         }
     }
 
@@ -705,18 +714,20 @@ public:
             return this->positive() ? std::strong_ordering::greater : std::strong_ordering::less;
         UnscaledValue_t t = this->unscaled_value;
         UnscaledValue_t o = other.unscaled_value;
-        if (this->exponent > other.exponent) {
-            UnscaledValue_t b{base};
-            if (util::detail::pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))
-                return std::strong_ordering::less;  // t does fit into the same precision, while o does not
-            if (util::detail::mul_checked<OverflowMode::Checked>(o, b, o))
-                return std::strong_ordering::less;  // t does fit into the same precision, while o does not
-        } else if (this->exponent < other.exponent) {
-            UnscaledValue_t b{base};
-            if (util::detail::pow_checked<OverflowMode::Checked>(b, other.exponent - this->exponent, b))
-                return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
-            if (util::detail::mul_checked<OverflowMode::Checked>(t, b, t))
-                return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
+        if (t != 0 && o != 0) {  // if one of the decimals is 0, compare directly (0*base^e is 0 for all e)
+            if (this->exponent > other.exponent) {
+                UnscaledValue_t b{base};
+                if (util::detail::pow_checked<OverflowMode::Checked>(b, this->exponent - other.exponent, b))
+                    return std::strong_ordering::less;  // t does fit into the same precision, while o does not
+                if (util::detail::mul_checked<OverflowMode::Checked>(o, b, o))
+                    return std::strong_ordering::less;  // t does fit into the same precision, while o does not
+            } else if (this->exponent < other.exponent) {
+                UnscaledValue_t b{base};
+                if (util::detail::pow_checked<OverflowMode::Checked>(b, other.exponent - this->exponent, b))
+                    return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
+                if (util::detail::mul_checked<OverflowMode::Checked>(t, b, t))
+                    return std::strong_ordering::greater;  // o does fit into the same precision, while t does not
+            }
         }
         if (t < o)
             return std::strong_ordering::less;

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2412,7 +2412,7 @@ std::optional<Year> Literal::year() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
     if (!casted.has_value())
         return std::nullopt;
-    auto [date, _] = util::deconstruct_timepoint(casted->first);
+    auto [date, _] = *util::deconstruct_timepoint(casted->first);
     return date.year();
 }
 
@@ -2430,7 +2430,7 @@ std::optional<std::chrono::month> Literal::month() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
     if (!casted.has_value())
         return std::nullopt;
-    auto [date, _] = util::deconstruct_timepoint(casted->first);
+    auto [date, _] = *util::deconstruct_timepoint(casted->first);
     return date.month();
 }
 
@@ -2448,7 +2448,7 @@ std::optional<std::chrono::day> Literal::day() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
     if (!casted.has_value())
         return std::nullopt;
-    auto [date, _] = util::deconstruct_timepoint(casted->first);
+    auto [date, _] = *util::deconstruct_timepoint(casted->first);
     return date.day();
 }
 
@@ -2465,7 +2465,7 @@ std::optional<std::chrono::hours> Literal::hours() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
     if (!casted.has_value())
         return std::nullopt;
-    auto [_, time] = util::deconstruct_timepoint(casted->first);
+    auto [_, time] = *util::deconstruct_timepoint(casted->first);
     return std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)}.hours();
 }
 
@@ -2482,7 +2482,7 @@ std::optional<std::chrono::minutes> Literal::minutes() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
     if (!casted.has_value())
         return std::nullopt;
-    auto [_, time] = util::deconstruct_timepoint(casted->first);
+    auto [_, time] = *util::deconstruct_timepoint(casted->first);
     return std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)}.minutes();
 }
 
@@ -2499,7 +2499,7 @@ std::optional<std::chrono::nanoseconds> Literal::seconds() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
     if (!casted.has_value())
         return std::nullopt;
-    auto [_, t] = util::deconstruct_timepoint(casted->first);
+    auto [_, t] = *util::deconstruct_timepoint(casted->first);
     std::chrono::hh_mm_ss const time{std::chrono::duration_cast<std::chrono::nanoseconds>(t)};
     return time.seconds() + time.subseconds();
 }

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2416,73 +2416,84 @@ Literal Literal::now(storage::DynNodeStoragePtr node_storage) {
 }
 
 std::optional<Year> Literal::year() const noexcept {
-    if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Date>()
-            && !datatype_eq<datatypes::xsd::GYearMonth>() && !datatype_eq<datatypes::xsd::GYear>())
+    if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Date>() && !datatype_eq<datatypes::xsd::GYearMonth>() && !datatype_eq<datatypes::xsd::GYear>()) {
         return std::nullopt;
+    }
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto [date, _] = *util::deconstruct_timepoint(casted->first);
     return date.year();
 }
 
 Literal Literal::as_year(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->year();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_typed_from_value<datatypes::xsd::Integer>(static_cast<int64_t>(*r), select_node_storage(node_storage));
 }
 
 std::optional<std::chrono::month> Literal::month() const noexcept {
     if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Date>()
-        && !datatype_eq<datatypes::xsd::GYearMonth>() && !datatype_eq<datatypes::xsd::GMonthDay>() && !datatype_eq<datatypes::xsd::GMonth>())
+            && !datatype_eq<datatypes::xsd::GYearMonth>() && !datatype_eq<datatypes::xsd::GMonthDay>() && !datatype_eq<datatypes::xsd::GMonth>()) {
         return std::nullopt;
+    }
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto [date, _] = *util::deconstruct_timepoint(casted->first);
     return date.month();
 }
 
 Literal Literal::as_month(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->month();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_typed_from_value<datatypes::xsd::Integer>(static_cast<unsigned int>(*r), select_node_storage(node_storage));
 }
 
 std::optional<std::chrono::day> Literal::day() const noexcept {
     if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Date>()
-        && !datatype_eq<datatypes::xsd::GMonthDay>() && !datatype_eq<datatypes::xsd::GDay>())
+            && !datatype_eq<datatypes::xsd::GMonthDay>() && !datatype_eq<datatypes::xsd::GDay>()) {
         return std::nullopt;
+    }
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto [date, _] = *util::deconstruct_timepoint(casted->first);
     return date.day();
 }
 
 Literal Literal::as_day(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->day();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_typed_from_value<datatypes::xsd::Integer>(static_cast<unsigned int>(*r), select_node_storage(node_storage));
 }
 
 std::optional<std::chrono::hours> Literal::hours() const noexcept {
-    if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Time>())
+    if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Time>()) {
         return std::nullopt;
+    }
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto [_, time] = *util::deconstruct_timepoint(casted->first);
     return std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)}.hours();
 }
 
 Literal Literal::as_hours(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->hours();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_typed_from_value<datatypes::xsd::Integer>(r->count(), select_node_storage(node_storage));
 }
 
@@ -2490,25 +2501,29 @@ std::optional<std::chrono::minutes> Literal::minutes() const noexcept {
     if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Time>())
         return std::nullopt;
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto [_, time] = *util::deconstruct_timepoint(casted->first);
     return std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)}.minutes();
 }
 
 Literal Literal::as_minutes(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->minutes();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_typed_from_value<datatypes::xsd::Integer>(r->count(), select_node_storage(node_storage));
 }
 
 std::optional<std::chrono::nanoseconds> Literal::seconds() const noexcept {
-    if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Time>())
+    if (!datatype_eq<datatypes::xsd::DateTime>() && !datatype_eq<datatypes::xsd::DateTimeStamp>() && !datatype_eq<datatypes::xsd::Time>()) {
         return std::nullopt;
+    }
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto [_, t] = *util::deconstruct_timepoint(casted->first);
     std::chrono::hh_mm_ss const time{std::chrono::duration_cast<std::chrono::nanoseconds>(t)};
     return time.seconds() + time.subseconds();
@@ -2516,39 +2531,49 @@ std::optional<std::chrono::nanoseconds> Literal::seconds() const noexcept {
 
 Literal Literal::as_seconds(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->seconds();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
-    return Literal::make_typed_from_value<datatypes::xsd::Decimal>(Decimal128{r->count(), 9}, select_node_storage(node_storage));
+    }
+    using dur = std::remove_cvref_t<decltype(*r)>;
+    static_assert(dur::period::num == 1);
+    static constexpr auto ex = rdf4cpp::datatypes::registry::util::chrono_max_canonical_string_chars::sub_seconds;
+    static_assert(Decimal128{dur{std::chrono::seconds{1}}.count(), ex} == Decimal128{1, 0});
+    return Literal::make_typed_from_value<datatypes::xsd::Decimal>(Decimal128{r->count(), ex}, select_node_storage(node_storage));
 }
 
 std::optional<Timezone> Literal::timezone() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto tz = casted->second;
     return tz;
 }
 
 Literal Literal::as_timezone(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->timezone();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_typed_from_value<datatypes::xsd::DayTimeDuration>(r->offset, select_node_storage(node_storage));
 }
 
 std::optional<std::string> Literal::tz() const noexcept {
     auto casted = this->cast_to_value<datatypes::xsd::DateTime>();
-    if (!casted.has_value())
+    if (!casted.has_value()) {
         return std::nullopt;
+    }
     auto tz = casted->second;
-    if (!tz.has_value())
+    if (!tz.has_value()) {
         return "";
+    }
     return tz->to_canonical_string();
 }
 Literal Literal::as_tz(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->tz();
-    if (!r.has_value())
+    if (!r.has_value()) {
         return Literal{};
+    }
     return Literal::make_simple_unchecked(*r, false, select_node_storage(node_storage));
 }
 

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2423,7 +2423,11 @@ std::optional<Year> Literal::year() const noexcept {
     if (!casted.has_value()) {
         return std::nullopt;
     }
-    auto [date, _] = *util::deconstruct_timepoint(casted->first);
+    auto dec = util::deconstruct_timepoint(casted->first);
+    if (!dec.has_value()) [[unlikely]] {
+        return std::nullopt;
+    }
+    auto [date, _] = *dec;
     return date.year();
 }
 
@@ -2444,7 +2448,11 @@ std::optional<std::chrono::month> Literal::month() const noexcept {
     if (!casted.has_value()) {
         return std::nullopt;
     }
-    auto [date, _] = *util::deconstruct_timepoint(casted->first);
+    auto dec = util::deconstruct_timepoint(casted->first);
+    if (!dec.has_value()) [[unlikely]] {
+        return std::nullopt;
+    }
+    auto [date, _] = *dec;
     return date.month();
 }
 
@@ -2465,7 +2473,11 @@ std::optional<std::chrono::day> Literal::day() const noexcept {
     if (!casted.has_value()) {
         return std::nullopt;
     }
-    auto [date, _] = *util::deconstruct_timepoint(casted->first);
+    auto dec = util::deconstruct_timepoint(casted->first);
+    if (!dec.has_value()) [[unlikely]] {
+        return std::nullopt;
+    }
+    auto [date, _] = *dec;
     return date.day();
 }
 
@@ -2485,7 +2497,11 @@ std::optional<std::chrono::hours> Literal::hours() const noexcept {
     if (!casted.has_value()) {
         return std::nullopt;
     }
-    auto [_, time] = *util::deconstruct_timepoint(casted->first);
+    auto dec = util::deconstruct_timepoint(casted->first);
+    if (!dec.has_value()) [[unlikely]] {
+        return std::nullopt;
+    }
+    auto [_, time] = *dec;
     return std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)}.hours();
 }
 
@@ -2504,7 +2520,11 @@ std::optional<std::chrono::minutes> Literal::minutes() const noexcept {
     if (!casted.has_value()) {
         return std::nullopt;
     }
-    auto [_, time] = *util::deconstruct_timepoint(casted->first);
+    auto dec = util::deconstruct_timepoint(casted->first);
+    if (!dec.has_value()) [[unlikely]] {
+        return std::nullopt;
+    }
+    auto [_, time] = *dec;
     return std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)}.minutes();
 }
 
@@ -2524,7 +2544,11 @@ std::optional<std::chrono::nanoseconds> Literal::seconds() const noexcept {
     if (!casted.has_value()) {
         return std::nullopt;
     }
-    auto [_, t] = *util::deconstruct_timepoint(casted->first);
+    auto dec = util::deconstruct_timepoint(casted->first);
+    if (!dec.has_value()) [[unlikely]] {
+        return std::nullopt;
+    }
+    auto [_, t] = *dec;
     std::chrono::hh_mm_ss const time{std::chrono::duration_cast<std::chrono::nanoseconds>(t)};
     return time.seconds() + time.subseconds();
 }

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -2518,7 +2518,7 @@ Literal Literal::as_seconds(storage::DynNodeStoragePtr node_storage) const {
     auto r = this->seconds();
     if (!r.has_value())
         return Literal{};
-    return Literal::make_typed_from_value<datatypes::xsd::Decimal>(rdf4cpp::BigDecimal<>{r->count(), 9}, select_node_storage(node_storage));
+    return Literal::make_typed_from_value<datatypes::xsd::Decimal>(Decimal128{r->count(), 9}, select_node_storage(node_storage));
 }
 
 std::optional<Timezone> Literal::timezone() const noexcept {

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -429,25 +429,25 @@ namespace rdf4cpp {
             return day_;
         }
 
-        [[nodiscard]] constexpr std::optional<time_point<util::Int128>> to_time_point() const {
+        [[nodiscard]] constexpr std::optional<time_point<Int128>> to_time_point() const {
             static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
             static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
             static_assert(std::numeric_limits<boost::multiprecision::checked_int128_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-            util::CheckedIntegral<util::Int128> y = static_cast<int64_t>(year_);
+            util::CheckedIntegral<Int128> y = static_cast<int64_t>(year_);
             auto m = static_cast<unsigned int>(month_);
             auto d = static_cast<unsigned int>(day_);
             y -= m <= 2;
-            util::CheckedIntegral<util::Int128> const era = (y >= 0 ? y : y - 399) / 400;
+            util::CheckedIntegral<Int128> const era = (y >= 0 ? y : y - 399) / 400;
             auto const yoe = y - era * 400;                                    // [0, 399]
             auto const doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;  // [0, 365]
             auto const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;            // [0, 146096]
             // note that the epoch of system_clock is specified as 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970
-            time_point<util::CheckedIntegral<util::Int128>> const r{typename time_point<util::CheckedIntegral<util::Int128>>::duration{era * 146097 + static_cast<util::CheckedIntegral<util::Int128>>(doe) - 719468}};
+            time_point<util::CheckedIntegral<Int128>> const r{typename time_point<util::CheckedIntegral<Int128>>::duration{era * 146097 + static_cast<util::CheckedIntegral<Int128>>(doe) - 719468}};
             return util::from_checked(r);
         }
-        [[nodiscard]] constexpr std::optional<time_point_local<util::Int128>> to_time_point_local() const {
+        [[nodiscard]] constexpr std::optional<time_point_local<Int128>> to_time_point_local() const {
             auto const v = to_time_point();
-            return time_point_local<util::Int128>{v.value().time_since_epoch()};
+            return time_point_local<Int128>{v.value().time_since_epoch()};
         }
 
         [[nodiscard]] constexpr bool ok() const noexcept {
@@ -497,14 +497,14 @@ namespace rdf4cpp {
         }
     };
 
-    using DurationNano = std::chrono::duration<util::Int128, std::chrono::nanoseconds::period>;
+    using DurationNano = std::chrono::duration<Int128, std::chrono::nanoseconds::period>;
     using TimePoint = std::chrono::time_point<std::chrono::local_t, DurationNano>;
     // system_clock does not use leap seconds, as required by rdf (xsd)
     using TimePointSys = std::chrono::time_point<std::chrono::system_clock, DurationNano>;
     using ZonedTime = std::chrono::zoned_time<DurationNano, Timezone>;
 
     namespace util {
-        using DurationNano_Checked = std::chrono::duration<util::CheckedIntegral<util::Int128>, std::chrono::nanoseconds::period>;
+        using DurationNano_Checked = std::chrono::duration<util::CheckedIntegral<Int128>, std::chrono::nanoseconds::period>;
         using TimePoint_Checked = std::chrono::time_point<std::chrono::local_t, DurationNano_Checked>;
         using TimePointSys_Checked = std::chrono::time_point<std::chrono::system_clock, DurationNano_Checked>;
         using ZonedTime_Checked = std::chrono::zoned_time<DurationNano_Checked, Timezone>;

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -481,12 +481,6 @@ struct dice::hash::dice_hash_overload<Policy, rdf4cpp::OptionalTimezone> {
     }
 };
 template<typename Policy>
-struct dice::hash::dice_hash_overload<Policy, ::boost::multiprecision::checked_int128_t> {
-    static size_t dice_hash(::boost::multiprecision::cpp_int const &x) noexcept {
-        return dice::hash::dice_hash_templates<Policy>::dice_hash(::boost::multiprecision::hash_value(x));
-    }
-};
-template<typename Policy>
 struct dice::hash::dice_hash_overload<Policy, rdf4cpp::Year> {
     static size_t dice_hash(rdf4cpp::Year const &x) noexcept {
         return dice::hash::dice_hash_templates<Policy>::dice_hash(static_cast<int64_t>(x));

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -133,22 +133,22 @@ namespace rdf4cpp {
 
     namespace util {
         /**
-     * turns any duration to its CheckedIntegral counterpart.
-     * @tparam R
-     * @param v
-     * @return
-     */
+         * turns any duration to its CheckedIntegral counterpart.
+         * @tparam R
+         * @param v
+         * @return
+         */
         template<typename R, typename I>
         constexpr std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R> to_checked(std::chrono::duration<I, R> v) noexcept {
             return std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>{v.count()};
         }
         /**
-     * turns any CheckedIntegral duration back to its integer based duration.
-     * @note undefined behavior, if v is invalid
-     * @tparam R
-     * @param v
-     * @return
-     */
+         * turns any CheckedIntegral duration back to its integer based duration.
+         * @note undefined behavior, if v is invalid
+         * @tparam R
+         * @param v
+         * @return
+         */
         template<typename R, typename I>
         constexpr std::optional<std::chrono::duration<I, R>> from_checked(std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R> v) noexcept {
             if (v.count().is_invalid()) {
@@ -157,24 +157,24 @@ namespace rdf4cpp {
             return std::chrono::duration<I, R>{v.count().get_value()};
         }
         /**
-     * turns any time_point to its CheckedIntegral counterpart.
-     * @tparam C
-     * @tparam R
-     * @param v
-     * @return
-     */
+         * turns any time_point to its CheckedIntegral counterpart.
+         * @tparam C
+         * @tparam R
+         * @param v
+         * @return
+         */
         template<typename C, typename R, typename I>
         constexpr std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>> to_checked(std::chrono::time_point<C, std::chrono::duration<I, R>> v) noexcept {
             return std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>>{to_checked(v.time_since_epoch())};
         }
         /**
-     * turns any CheckedIntegral time_point back to its integer based time_point.
-     * @note undefined behavior, if v is invalid
-     * @tparam C
-     * @tparam R
-     * @param v
-     * @return
-     */
+         * turns any CheckedIntegral time_point back to its integer based time_point.
+         * @note undefined behavior, if v is invalid
+         * @tparam C
+         * @tparam R
+         * @param v
+         * @return
+         */
         template<typename C, typename R, typename I>
         constexpr std::optional<std::chrono::time_point<C, std::chrono::duration<I, R>>> from_checked(std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>> v) noexcept {
             if (v.time_since_epoch().count().is_invalid()) {
@@ -191,9 +191,9 @@ namespace rdf4cpp {
     using Day = std::chrono::day;
 
     /**
- * Like std::chrono::year, except it has a greater range.
- * adapted from https://howardhinnant.github.io/date_algorithms.html
- */
+     * Like std::chrono::year, except it has a greater range.
+     * adapted from https://howardhinnant.github.io/date_algorithms.html
+     */
     struct Year {
     private:
         int64_t value_;

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -144,7 +144,6 @@ namespace rdf4cpp {
         }
         /**
          * turns any CheckedIntegral duration back to its integer based duration.
-         * @note undefined behavior, if v is invalid
          * @tparam R
          * @param v
          * @return
@@ -169,7 +168,6 @@ namespace rdf4cpp {
         }
         /**
          * turns any CheckedIntegral time_point back to its integer based time_point.
-         * @note undefined behavior, if v is invalid
          * @tparam C
          * @tparam R
          * @param v

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -218,6 +218,13 @@ namespace rdf4cpp {
         friend constexpr Year operator+(std::chrono::years d, Year const &y) noexcept {
             return Year{y.value_ + d.count()};
         }
+        [[nodiscard]] constexpr std::optional<Year> add_checked(std::chrono::years d) const noexcept {
+            int64_t r;
+            if (util::detail::add_checked<util::detail::OverflowMode::Checked>(value_, d.count(), r)) {
+                return std::nullopt;
+            }
+            return Year{r};
+        }
 
         constexpr Year operator+=(std::chrono::years d) noexcept {
             *this = *this + d;
@@ -229,6 +236,20 @@ namespace rdf4cpp {
         }
         friend constexpr std::chrono::years operator-(Year const &a, Year const &b) noexcept {
             return std::chrono::years{a.value_ - b.value_};
+        }
+        [[nodiscard]] constexpr std::optional<Year> sub_checked(std::chrono::years d) const noexcept {
+            int64_t r;
+            if (util::detail::sub_checked<util::detail::OverflowMode::Checked>(value_, d.count(), r)) {
+                return std::nullopt;
+            }
+            return Year{r};
+        }
+        [[nodiscard]] constexpr std::optional<std::chrono::years> sub_checked(Year o) const noexcept {
+            int64_t r;
+            if (util::detail::sub_checked<util::detail::OverflowMode::Checked>(this->value_, o.value_, r)) {
+                return std::nullopt;
+            }
+            return std::chrono::years{r};
         }
 
         constexpr Year operator-=(std::chrono::years d) noexcept {
@@ -269,15 +290,21 @@ namespace rdf4cpp {
         Year year_ = Year{0};
         Month month_ = Month{1};
 
-        static constexpr YearMonth create_normalized(int64_t y, int64_t mo) noexcept {
-            --mo;
+        // returns nullopt iff overflow
+        static constexpr std::optional<YearMonth> create_normalized(util::CheckedIntegral<int64_t> y, util::CheckedIntegral<int64_t> mo) noexcept {
+            mo -= 1;
             y += mo / 12;
             mo %= 12;
             if (mo < 0) {  // fix result of % being in [-11,11]
-                --y;
+                y -= 1;
                 mo += 12;
             }
-            return YearMonth{Year{y}, std::chrono::month{static_cast<unsigned int>(mo + 1)}};
+            mo += 1;
+            auto um = mo.checked_cast<unsigned int>();
+            if (y.is_invalid() || um.is_invalid()) {
+                return std::nullopt;
+            }
+            return YearMonth{Year{y.get_value()}, std::chrono::month{um.get_value()}};
         }
 
     public:
@@ -306,18 +333,27 @@ namespace rdf4cpp {
         friend constexpr YearMonth operator+(std::chrono::years d, YearMonth const &ym) noexcept {
             return YearMonth{ym.year_ + d, ym.month_};
         }
+        [[nodiscard]] constexpr std::optional<YearMonth> add_checked(std::chrono::years s) const noexcept {
+            auto y = year_.add_checked(s);
+            if (!y.has_value()) {
+                return std::nullopt;
+            }
+            return YearMonth{*y, month_};
+        }
 
         constexpr YearMonth &operator+=(std::chrono::years d) noexcept {
             *this = *this + d;
             return *this;
         }
-
-        // TODO overflow
-        friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::months d) noexcept {
-            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
+        
+        friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::months d) {
+            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count()).value();
         }
-        friend constexpr YearMonth operator+(std::chrono::months d, YearMonth const &ym) noexcept {
-            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
+        friend constexpr YearMonth operator+(std::chrono::months d, YearMonth const &ym) {
+            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count()).value();
+        }
+        [[nodiscard]] constexpr std::optional<YearMonth> add_checked(std::chrono::months d) const noexcept {
+            return create_normalized(static_cast<int64_t>(year_), util::CheckedIntegral<int64_t>(static_cast<unsigned int>(month_)) + d.count());
         }
 
         constexpr YearMonth &operator+=(std::chrono::months d) noexcept {
@@ -328,12 +364,34 @@ namespace rdf4cpp {
         friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::years d) noexcept {
             return {ym.year_ - d, ym.month_};
         }
-        friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::months d) noexcept {
-            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) - d.count());
+        [[nodiscard]] constexpr std::optional<YearMonth> sub_checked(std::chrono::years s) const noexcept {
+            auto y = year_.sub_checked(s);
+            if (!y.has_value()) {
+                return std::nullopt;
+            }
+            return YearMonth{*y, month_};
+        }
+        friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::months d) {
+            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) - d.count()).value();
+        }
+        [[nodiscard]] constexpr std::optional<YearMonth> sub_checked(std::chrono::months d) const noexcept {
+            return create_normalized(static_cast<int64_t>(year_), util::CheckedIntegral<int64_t>(static_cast<unsigned int>(month_)) - d.count());
         }
 
         friend constexpr std::chrono::months operator-(YearMonth const &a, YearMonth const &b) noexcept {
             return (a.year_ - b.year_) + (a.month_ - b.month_);
+        }
+        [[nodiscard]] constexpr std::optional<std::chrono::months> sub_checked(YearMonth const &o) const noexcept {
+            auto y = this->year_.sub_checked(o.year_);
+            if (!y.has_value()) {
+                return std::nullopt;
+            }
+            int64_t m;
+            if (util::detail::sub_checked<util::detail::OverflowMode::Checked, int64_t>(static_cast<unsigned int>(this->month_), static_cast<unsigned int>(o.month_), m)) {
+                return std::nullopt;
+            }
+            auto r = util::to_checked(*y) + std::chrono::months(m);
+            return util::from_checked(r);
         }
 
         constexpr YearMonth &operator-=(std::chrono::years d) noexcept {
@@ -429,25 +487,26 @@ namespace rdf4cpp {
             return day_;
         }
 
-        [[nodiscard]] constexpr std::optional<time_point<Int128>> to_time_point() const {
+        // with year as int64 and timepoint as int128, guaranteed to not overflow
+        [[nodiscard]] constexpr time_point<Int128> to_time_point() const {
             static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
             static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-            static_assert(std::numeric_limits<boost::multiprecision::checked_int128_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-            util::CheckedIntegral<Int128> y = static_cast<int64_t>(year_);
+            static_assert(std::numeric_limits<Int128>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
+            Int128 y = static_cast<int64_t>(year_);
             auto m = static_cast<unsigned int>(month_);
             auto d = static_cast<unsigned int>(day_);
             y -= m <= 2;
-            util::CheckedIntegral<Int128> const era = (y >= 0 ? y : y - 399) / 400;
+            Int128 const era = (y >= 0 ? y : y - 399) / 400;
             auto const yoe = y - era * 400;                                    // [0, 399]
             auto const doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;  // [0, 365]
             auto const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;            // [0, 146096]
             // note that the epoch of system_clock is specified as 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970
-            time_point<util::CheckedIntegral<Int128>> const r{typename time_point<util::CheckedIntegral<Int128>>::duration{era * 146097 + static_cast<util::CheckedIntegral<Int128>>(doe) - 719468}};
-            return util::from_checked(r);
+            time_point<Int128> const r{typename time_point<Int128>::duration{era * 146097 + doe - 719468}};
+            return r;
         }
-        [[nodiscard]] constexpr std::optional<time_point_local<Int128>> to_time_point_local() const {
+        [[nodiscard]] constexpr time_point_local<Int128> to_time_point_local() const {
             auto const v = to_time_point();
-            return time_point_local<Int128>{v.value().time_since_epoch()};
+            return time_point_local<Int128>{v.time_since_epoch()};
         }
 
         [[nodiscard]] constexpr bool ok() const noexcept {
@@ -462,17 +521,31 @@ namespace rdf4cpp {
         friend constexpr YearMonthDay operator+(std::chrono::years d, YearMonthDay const &ym) noexcept {
             return {ym.year_ + d, ym.month_, ym.day_};
         }
+        [[nodiscard]] constexpr std::optional<YearMonthDay> add_checked(std::chrono::years d) const noexcept {
+            auto y = year_.add_checked(d);
+            if (!y.has_value()) {
+                return std::nullopt;
+            }
+            return YearMonthDay{*y, month_, day_};
+        }
 
         constexpr YearMonthDay &operator+=(std::chrono::years d) noexcept {
             *this = *this + d;
             return *this;
         }
 
-        friend constexpr YearMonthDay operator+(YearMonthDay const &d, std::chrono::months m) noexcept {
+        friend constexpr YearMonthDay operator+(YearMonthDay const &d, std::chrono::months m) {
             return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
         }
-        friend constexpr YearMonthDay operator+(std::chrono::months m, YearMonthDay const &d) noexcept {
+        friend constexpr YearMonthDay operator+(std::chrono::months m, YearMonthDay const &d) {
             return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
+        }
+        [[nodiscard]] constexpr std::optional<YearMonthDay> add_checked(std::chrono::months d) const noexcept {
+            auto ym = YearMonth{year_, month_}.add_checked(d);
+            if (!ym.has_value()) {
+                return std::nullopt;
+            }
+            return YearMonthDay{*ym, day_};
         }
 
         constexpr YearMonthDay &operator+=(std::chrono::months d) noexcept {
@@ -483,8 +556,22 @@ namespace rdf4cpp {
         friend constexpr YearMonthDay operator-(YearMonthDay const &ym, std::chrono::years d) noexcept {
             return {ym.year_ - d, ym.month_, ym.day_};
         }
-        friend constexpr YearMonthDay operator-(YearMonthDay const &d, std::chrono::months m) noexcept {
+        friend constexpr YearMonthDay operator-(YearMonthDay const &d, std::chrono::months m) {
             return YearMonthDay{YearMonth{d.year_, d.month_} - m, d.day_};
+        }
+        [[nodiscard]] constexpr std::optional<YearMonthDay> sub_checked(std::chrono::years d) const noexcept {
+            auto y = year_.sub_checked(d);
+            if (!y.has_value()) {
+                return std::nullopt;
+            }
+            return YearMonthDay{*y, month_, day_};
+        }
+        [[nodiscard]] constexpr std::optional<YearMonthDay> sub_checked(std::chrono::months d) const noexcept {
+            auto ym = YearMonth{year_, month_}.sub_checked(d);
+            if (!ym.has_value()) {
+                return std::nullopt;
+            }
+            return YearMonthDay{*ym, day_};
         }
 
         constexpr YearMonthDay &operator-=(std::chrono::years d) noexcept {
@@ -515,15 +602,12 @@ namespace rdf4cpp {
         // implementation defined, not from standard
         inline constexpr Timezone time_point_replacement_timezone{std::chrono::minutes{0}};
 
-        // TODO check return values
-        constexpr std::optional<TimePoint> construct_timepoint(YearMonthDay const &date, DurationNano const &time_of_day) noexcept {
+        // with year as int64 and timepoint as int128, guaranteed to not overflow
+        constexpr TimePoint construct_timepoint(YearMonthDay const &date, DurationNano const &time_of_day) noexcept {
             auto sd = date.to_time_point_local();
-            if (!sd.has_value()) {
-                return std::nullopt;
-            }
-            auto ms = static_cast<TimePoint_Checked>(to_checked(*sd));
+            auto ms = static_cast<TimePoint>(sd);
             ms += time_of_day;
-            return from_checked(ms);
+            return ms;
         }
 
         // TODO check return values

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -9,453 +9,541 @@
 
 #include <rdf4cpp/datatypes/rdf.hpp>
 #include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
-
-#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/util/CheckedInt.hpp>
 
 namespace rdf4cpp {
-struct Timezone {
-    // heavily inspired by https://howardhinnant.github.io/date/tz.html#Examples
+    struct Timezone {
+        // heavily inspired by https://howardhinnant.github.io/date/tz.html#Examples
 
-    std::chrono::minutes offset = std::chrono::minutes{0};
+        std::chrono::minutes offset = std::chrono::minutes{0};
 
-    static constexpr const char *begin_tokens = "Z+-";
+        static constexpr char const *begin_tokens = "Z+-";
 
-    constexpr Timezone() = default;
+        constexpr Timezone() = default;
 
-    inline explicit Timezone(const std::chrono::time_zone *tz, std::chrono::time_point<std::chrono::system_clock> n = std::chrono::system_clock::now())
-        : offset(std::chrono::duration_cast<std::chrono::minutes>(tz->get_info(n).offset)) {
-    }
+        inline explicit Timezone(std::chrono::time_zone const *tz, std::chrono::time_point<std::chrono::system_clock> n = std::chrono::system_clock::now())
+            : offset(std::chrono::duration_cast<std::chrono::minutes>(tz->get_info(n).offset)) {
+        }
 
-    constexpr explicit Timezone(std::chrono::hours h) noexcept
-        : offset(h) {}
+        constexpr explicit Timezone(std::chrono::hours h) noexcept
+            : offset(h) {
+        }
 
-    constexpr explicit Timezone(std::chrono::minutes h) noexcept
-        : offset(h) {}
+        constexpr explicit Timezone(std::chrono::minutes h) noexcept
+            : offset(h) {
+        }
 
-    constexpr auto operator<=>(const Timezone &) const noexcept = default;
+        constexpr auto operator<=>(Timezone const &) const noexcept = default;
 
-    static constexpr Timezone parse(std::string_view v, std::string_view dt) {
-        Timezone tz{};
-        if (v == "Z") {
+        static constexpr Timezone parse(std::string_view v, std::string_view dt) {
+            Timezone tz{};
+            if (v == "Z") {
+                return tz;
+            }
+            bool negative = false;
+            if (v[0] == '-') {
+                negative = true;
+            }
+            v = v.substr(1);
+            auto sep = v.find(':');
+            if (sep == std::string::npos) {
+                throw InvalidNode{std::format("{} parsing error: timezone expected :", dt)};
+            }
+            std::chrono::hours const h{datatypes::registry::util::from_chars<int32_t, "timezone">(v.substr(0, sep))};
+            tz.offset = std::chrono::minutes{datatypes::registry::util::from_chars<int32_t, "timezone">(v.substr(sep + 1))} + std::chrono::minutes{h};
+            if (negative) {
+                tz.offset *= -1;
+            }
+            if (tz.offset.count() < -840 || tz.offset.count() > 840) {
+                throw InvalidNode{std::format("{} parsing error: timezone offset too big", dt)};
+            }
             return tz;
         }
-        bool negative = false;
-        if (v[0] == '-') {
-            negative = true;
-        }
-        v = v.substr(1);
-        auto sep = v.find(':');
-        if (sep == std::string::npos) {
-            throw InvalidNode{std::format("{} parsing error: timezone expected :", dt)};
-        }
-        std::chrono::hours const h{datatypes::registry::util::from_chars<int32_t, "timezone">(v.substr(0, sep))};
-        tz.offset = std::chrono::minutes{datatypes::registry::util::from_chars<int32_t, "timezone">(v.substr(sep + 1))} + std::chrono::minutes{h};
-        if (negative) {
-            tz.offset *= -1;
-        }
-        if (tz.offset.count() < -840 || tz.offset.count() > 840) {
-            throw InvalidNode{std::format("{} parsing error: timezone offset too big", dt)};
-        }
-        return tz;
-    }
 
-    static constexpr std::optional<Timezone> parse_optional(std::string_view &s, std::string_view dt) {
-        auto p = s.find_first_of(begin_tokens, 1);
-        if (p == 0 || p == std::string::npos)
-            return std::nullopt;
-        auto pre = s.substr(0, p);
-        auto tz = parse(s.substr(p), dt);
-        s = pre;
-        return tz;
-    }
-
-    // sign, hours, :, minutes
-    static constexpr size_t max_canonical_string_chars = 1+(std::numeric_limits<int64_t>::digits10+1)+1+2;
-    template<std::output_iterator<char> T>
-    T to_canonical_string(T o) const noexcept {
-        if (offset == std::chrono::minutes{0}) {
-            *o = 'Z';
-            ++o;
-            return o;
+        static constexpr std::optional<Timezone> parse_optional(std::string_view &s, std::string_view dt) {
+            auto p = s.find_first_of(begin_tokens, 1);
+            if (p == 0 || p == std::string::npos)
+                return std::nullopt;
+            auto pre = s.substr(0, p);
+            auto tz = parse(s.substr(p), dt);
+            s = pre;
+            return tz;
         }
-        auto h = std::chrono::floor<std::chrono::hours>(std::chrono::abs(offset));
-        auto m = std::chrono::abs(offset) - h;
-        return std::format_to(o, "{}{:02}:{:02}", offset >= std::chrono::minutes{0} ? '+' : '-', h.count(), m.count());
-    }
-    [[nodiscard]] std::string to_canonical_string() const noexcept {
-        std::string buf{};
-        buf.reserve(max_canonical_string_chars);
-        to_canonical_string(std::back_inserter(buf));
-        return buf;
-    }
 
-    [[nodiscard]] const std::chrono::time_zone *get_tz(std::chrono::time_point<std::chrono::system_clock> n = std::chrono::system_clock::now()) const {
-        for (const auto &tz : std::chrono::get_tzdb().zones) {
-            if (tz.get_info(n).offset == std::chrono::seconds(offset)) {
-                return &tz;
+        // sign, hours, :, minutes
+        static constexpr size_t max_canonical_string_chars = 1 + (std::numeric_limits<int64_t>::digits10 + 1) + 1 + 2;
+        template<std::output_iterator<char> T>
+        T to_canonical_string(T o) const noexcept {
+            if (offset == std::chrono::minutes{0}) {
+                *o = 'Z';
+                ++o;
+                return o;
             }
+            auto h = std::chrono::floor<std::chrono::hours>(std::chrono::abs(offset));
+            auto m = std::chrono::abs(offset) - h;
+            return std::format_to(o, "{}{:02}:{:02}", offset >= std::chrono::minutes{0} ? '+' : '-', h.count(), m.count());
         }
-        return nullptr;
-    }
+        [[nodiscard]] std::string to_canonical_string() const noexcept {
+            std::string buf{};
+            buf.reserve(max_canonical_string_chars);
+            to_canonical_string(std::back_inserter(buf));
+            return buf;
+        }
 
-    template<typename Duration>
-    [[nodiscard]] auto to_sys(const std::chrono::local_time<Duration> &tp) const noexcept {
-        return std::chrono::sys_time<std::common_type_t<Duration, std::chrono::seconds>>{(tp - offset).time_since_epoch()};
-    }
+        [[nodiscard]] std::chrono::time_zone const *get_tz(std::chrono::time_point<std::chrono::system_clock> n = std::chrono::system_clock::now()) const {
+            for (auto const &tz : std::chrono::get_tzdb().zones) {
+                if (tz.get_info(n).offset == std::chrono::seconds(offset)) {
+                    return &tz;
+                }
+            }
+            return nullptr;
+        }
 
-    template<typename Duration>
-    [[nodiscard]] auto to_local(const std::chrono::sys_time<Duration> &tp) const noexcept {
-        return std::chrono::local_time<std::common_type_t<Duration, std::chrono::seconds>>{(tp + offset).time_since_epoch()};
-    }
+        template<typename Duration>
+        [[nodiscard]] auto to_sys(std::chrono::local_time<Duration> const &tp) const noexcept {
+            return std::chrono::sys_time<std::common_type_t<Duration, std::chrono::seconds>>{(tp - offset).time_since_epoch()};
+        }
 
-    template<typename Duration>
-    [[nodiscard]] std::chrono::sys_info get_info(const std::chrono::sys_time<Duration> &) const noexcept {
-        return std::chrono::sys_info{
-                std::chrono::sys_seconds{std::chrono::seconds{0L}},
-                std::chrono::sys_seconds{std::chrono::seconds{std::numeric_limits<int64_t>::max()}},
-                offset,
-                std::chrono::minutes{0},
-                to_canonical_string()};
-    }
+        template<typename Duration>
+        [[nodiscard]] auto to_local(std::chrono::sys_time<Duration> const &tp) const noexcept {
+            return std::chrono::local_time<std::common_type_t<Duration, std::chrono::seconds>>{(tp + offset).time_since_epoch()};
+        }
 
-    const Timezone *operator->() const noexcept {
-        return this;
-    }
+        template<typename Duration>
+        [[nodiscard]] std::chrono::sys_info get_info(std::chrono::sys_time<Duration> const &) const noexcept {
+            return std::chrono::sys_info{
+                    std::chrono::sys_seconds{std::chrono::seconds{0L}},
+                    std::chrono::sys_seconds{std::chrono::seconds{std::numeric_limits<int64_t>::max()}},
+                    offset,
+                    std::chrono::minutes{0},
+                    to_canonical_string()};
+        }
 
-    static constexpr Timezone max_value() noexcept {
-        return Timezone{std::chrono::hours{14}};
+        Timezone const *operator->() const noexcept {
+            return this;
+        }
+
+        static constexpr Timezone max_value() noexcept {
+            return Timezone{std::chrono::hours{14}};
+        };
+        static constexpr Timezone min_value() noexcept {
+            return Timezone{std::chrono::hours{-14}};
+        };
     };
-    static constexpr Timezone min_value() noexcept {
-        return Timezone{std::chrono::hours{-14}};
-    };
-};
 
-using OptionalTimezone = std::optional<Timezone>;
+    namespace util {
+        /**
+     * turns any duration to its CheckedIntegral counterpart.
+     * @tparam R
+     * @param v
+     * @return
+     */
+        template<typename R, typename I>
+        constexpr std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R> to_checked(std::chrono::duration<I, R> v) noexcept {
+            return std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>{v.count()};
+        }
+        /**
+     * turns any CheckedIntegral duration back to its integer based duration.
+     * @note undefined behavior, if v is invalid
+     * @tparam R
+     * @param v
+     * @return
+     */
+        template<typename R, typename I>
+        constexpr std::optional<std::chrono::duration<I, R>> from_checked(std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R> v) noexcept {
+            if (v.count().is_invalid()) {
+                return std::nullopt;
+            }
+            return std::chrono::duration<I, R>{v.count().get_value()};
+        }
+        /**
+     * turns any time_point to its CheckedIntegral counterpart.
+     * @tparam C
+     * @tparam R
+     * @param v
+     * @return
+     */
+        template<typename C, typename R, typename I>
+        constexpr std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>> to_checked(std::chrono::time_point<C, std::chrono::duration<I, R>> v) noexcept {
+            return std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>>{to_checked(v.time_since_epoch())};
+        }
+        /**
+     * turns any CheckedIntegral time_point back to its integer based time_point.
+     * @note undefined behavior, if v is invalid
+     * @tparam C
+     * @tparam R
+     * @param v
+     * @return
+     */
+        template<typename C, typename R, typename I>
+        constexpr std::optional<std::chrono::time_point<C, std::chrono::duration<I, R>>> from_checked(std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<I>, R>> v) noexcept {
+            if (v.time_since_epoch().count().is_invalid()) {
+                return std::nullopt;
+            }
+            return std::chrono::time_point<C, std::chrono::duration<I, R>>{*from_checked(v.time_since_epoch())};
+        }
+    }  // namespace util
 
-using Month = std::chrono::month;
-using Day = std::chrono::day;
 
-/**
+    using OptionalTimezone = std::optional<Timezone>;
+
+    using Month = std::chrono::month;
+    using Day = std::chrono::day;
+
+    /**
  * Like std::chrono::year, except it has a greater range.
  * adapted from https://howardhinnant.github.io/date_algorithms.html
  */
-struct Year {
-private:
-    int64_t value_;
+    struct Year {
+    private:
+        int64_t value_;
 
-public:
-    explicit constexpr Year(int64_t y = 0) noexcept : value_{y} {
-    }
-
-    constexpr explicit operator int64_t() const noexcept {
-        return value_;
-    }
-
-    [[nodiscard]] constexpr bool is_leap() const noexcept(noexcept(value_ % 100)) {
-        return value_ % 4 == 0 && (value_ % 100 != 0 || value_ % 400 == 0);
-    }
-
-    constexpr auto operator<=>(Year const &) const noexcept = default;
-
-    friend constexpr Year operator+(Year const &y, std::chrono::years d) noexcept {
-        return Year{y.value_ + d.count()};
-    }
-    friend constexpr Year operator+(std::chrono::years d, Year const &y) noexcept {
-        return Year{y.value_ + d.count()};
-    }
-
-    constexpr Year operator+=(std::chrono::years d) noexcept {
-        *this = *this + d;
-        return *this;
-    }
-
-    friend constexpr Year operator-(Year const &y, std::chrono::years d) noexcept {
-        return Year{y.value_ - d.count()};
-    }
-    friend constexpr std::chrono::years operator-(Year const &a, Year const &b) noexcept {
-        return std::chrono::years{a.value_ - b.value_};
-    }
-
-    constexpr Year operator-=(std::chrono::years d) noexcept {
-        *this = *this - d;
-        return *this;
-    }
-
-    constexpr Year &operator++() noexcept {
-        *this += std::chrono::years{1};
-        return *this;
-    }
-    constexpr Year operator++(int) noexcept {
-        Year r = *this;
-        ++(*this);
-        return r;
-    }
-
-    constexpr Year &operator--() noexcept {
-        *this -= std::chrono::years{1};
-        return *this;
-    }
-    constexpr Year operator--(int) noexcept {
-        Year r = *this;
-        --(*this);
-        return r;
-    }
-
-    static constexpr Year max() noexcept {
-        return Year{std::numeric_limits<int64_t>::max()};
-    }
-    static constexpr Year min() noexcept {
-        return Year{std::numeric_limits<int64_t>::min()};
-    }
-};
-
-struct YearMonth {
-private:
-    Year year_ = Year{0};
-    Month month_ = Month{1};
-
-    static constexpr YearMonth create_normalized(int64_t y, int64_t mo) noexcept {
-        --mo;
-        y += mo / 12;
-        mo %= 12;
-        if (mo < 0) { // fix result of % being in [-11,11]
-            --y;
-            mo += 12;
+    public:
+        explicit constexpr Year(int64_t y = 0) noexcept : value_{y} {
         }
-        return YearMonth{Year{y}, std::chrono::month{static_cast<unsigned int>(mo+1)}};
-    }
 
-public:
-    constexpr YearMonth() noexcept = default;
+        constexpr explicit operator int64_t() const noexcept {
+            return value_;
+        }
 
-    constexpr YearMonth(Year y, std::chrono::month m) noexcept : year_{y}, month_{m} {
-    }
+        [[nodiscard]] constexpr bool is_leap() const noexcept(noexcept(value_ % 100)) {
+            return value_ % 4 == 0 && (value_ % 100 != 0 || value_ % 400 == 0);
+        }
 
-    [[nodiscard]] constexpr Year year() const noexcept {
-        return year_;
-    }
+        constexpr auto operator<=>(Year const &) const noexcept = default;
 
-    [[nodiscard]] constexpr Month month() const noexcept {
-        return month_;
-    }
+        friend constexpr Year operator+(Year const &y, std::chrono::years d) noexcept {
+            return Year{y.value_ + d.count()};
+        }
+        friend constexpr Year operator+(std::chrono::years d, Year const &y) noexcept {
+            return Year{y.value_ + d.count()};
+        }
 
-    constexpr auto operator<=>(YearMonth const &) const noexcept = default;
+        constexpr Year operator+=(std::chrono::years d) noexcept {
+            *this = *this + d;
+            return *this;
+        }
 
-    [[nodiscard]] constexpr bool ok() const noexcept {
-        return month_.ok();
-    }
+        friend constexpr Year operator-(Year const &y, std::chrono::years d) noexcept {
+            return Year{y.value_ - d.count()};
+        }
+        friend constexpr std::chrono::years operator-(Year const &a, Year const &b) noexcept {
+            return std::chrono::years{a.value_ - b.value_};
+        }
 
-    friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::years d) noexcept {
-        return YearMonth{ym.year_ + d, ym.month_};
-    }
-    friend constexpr YearMonth operator+(std::chrono::years d, YearMonth const &ym) noexcept {
-        return YearMonth{ym.year_ + d, ym.month_};
-    }
+        constexpr Year operator-=(std::chrono::years d) noexcept {
+            *this = *this - d;
+            return *this;
+        }
 
-    constexpr YearMonth& operator+=(std::chrono::years d) noexcept {
-        *this = *this + d;
-        return *this;
-    }
+        constexpr Year &operator++() noexcept {
+            *this += std::chrono::years{1};
+            return *this;
+        }
+        constexpr Year operator++(int) noexcept {
+            Year r = *this;
+            ++(*this);
+            return r;
+        }
 
-    friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::months d) noexcept {
-        return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
-    }
-    friend constexpr YearMonth operator+(std::chrono::months d, YearMonth const &ym) noexcept {
-        return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
-    }
+        constexpr Year &operator--() noexcept {
+            *this -= std::chrono::years{1};
+            return *this;
+        }
+        constexpr Year operator--(int) noexcept {
+            Year r = *this;
+            --(*this);
+            return r;
+        }
 
-    constexpr YearMonth& operator+=(std::chrono::months d) noexcept {
-        *this = *this + d;
-        return *this;
-    }
+        static constexpr Year max() noexcept {
+            return Year{std::numeric_limits<int64_t>::max()};
+        }
+        static constexpr Year min() noexcept {
+            return Year{std::numeric_limits<int64_t>::min()};
+        }
+    };
 
-    friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::years d) noexcept {
-        return {ym.year_ - d, ym.month_};
-    }
-    friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::months d) noexcept {
-        return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) - d.count());
-    }
+    struct YearMonth {
+    private:
+        Year year_ = Year{0};
+        Month month_ = Month{1};
 
-    friend constexpr std::chrono::months operator-(YearMonth const &a, YearMonth const &b) noexcept {
-        return (a.year_ - b.year_) + (a.month_ - b.month_);
-    }
+        static constexpr YearMonth create_normalized(int64_t y, int64_t mo) noexcept {
+            --mo;
+            y += mo / 12;
+            mo %= 12;
+            if (mo < 0) {  // fix result of % being in [-11,11]
+                --y;
+                mo += 12;
+            }
+            return YearMonth{Year{y}, std::chrono::month{static_cast<unsigned int>(mo + 1)}};
+        }
 
-    constexpr YearMonth& operator-=(std::chrono::years d) noexcept {
-        *this = *this - d;
-        return *this;
-    }
-    constexpr YearMonth& operator-=(std::chrono::months d) noexcept {
-        *this = *this - d;
-        return *this;
-    }
-};
+    public:
+        constexpr YearMonth() noexcept = default;
 
-struct YearMonthDay {
-    template<typename P>
-    using time_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<P, std::chrono::days::period>>;
-    template<typename P>
-    using time_point_local = std::chrono::time_point<std::chrono::local_t, std::chrono::duration<P, std::chrono::days::period>>;
+        constexpr YearMonth(Year y, std::chrono::month m) noexcept : year_{y}, month_{m} {
+        }
 
-private:
-    // adapted from https://howardhinnant.github.io/date_algorithms.html
-    Year year_ = Year{0};
-    Month month_ = Month{1};
-    Day day_ = Day{1};
+        [[nodiscard]] constexpr Year year() const noexcept {
+            return year_;
+        }
 
-    static constexpr std::chrono::day last_day_in_month(Year year, Month month) noexcept {
-        assert(month.ok());
-        constexpr unsigned char common[]{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-        auto m = static_cast<unsigned int>(month);
-        return std::chrono::day{m != 2 || !year.is_leap() ? common[m - 1] : 29u};
-    }
+        [[nodiscard]] constexpr Month month() const noexcept {
+            return month_;
+        }
 
-public:
-    constexpr YearMonthDay() noexcept  = default;
+        constexpr auto operator<=>(YearMonth const &) const noexcept = default;
 
-    constexpr explicit YearMonthDay(std::chrono::year_month_day ymd) noexcept
-        : year_(static_cast<int>(ymd.year())), month_(ymd.month()), day_(ymd.day()) {
-    }
-    constexpr YearMonthDay(Year const &y, Month m, std::chrono::day d) noexcept
-        : year_(y), month_(m), day_(d) {
-    }
-    constexpr YearMonthDay(Year const &y, Month m, std::chrono::last_spec) noexcept
-        : year_(y), month_(m), day_(last_day_in_month(y, m)) {
-    }
-    constexpr YearMonthDay(YearMonth const &ym, Day d) noexcept
-        : year_(ym.year()), month_(ym.month()), day_(d) {
-    }
-    constexpr YearMonthDay(YearMonth const &ym, std::chrono::last_spec) noexcept
-        : YearMonthDay(ym.year(), ym.month(), std::chrono::last) {
-    }
-    template<typename P>
-    constexpr explicit YearMonthDay(time_point<P> sd) noexcept(noexcept(P{} + P{} * P{} - P{} / P{})) {
-        static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
-        static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-        static_assert(std::numeric_limits<P>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-        P z = sd.time_since_epoch().count();
-        z += 719468;
-        P const era = (z >= 0 ? z : z - 146096) / 146097;
-        auto const doe = static_cast<P>(z - era * 146097);                    // [0, 146096]
-        auto const yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;  // [0, 399]
-        P const y = static_cast<P>(yoe) + era * 400;
-        auto const doy = doe - (365 * yoe + yoe / 4 - yoe / 100);  // [0, 365]
-        auto const mp = (5 * doy + 2) / 153;                       // [0, 11]
-        auto const d = doy - (153 * mp + 2) / 5 + 1;               // [1, 31]
-        auto const m = mp < 10 ? mp + 3 : mp - 9;                  // [1, 12]
-        year_ = Year{static_cast<int64_t>(y + (m <= 2))};
-        month_ = std::chrono::month{static_cast<unsigned>(m)};
-        day_ = std::chrono::day{static_cast<unsigned>(d)};
-    }
-    template<typename P>
-    constexpr explicit YearMonthDay(time_point_local<P> sd) noexcept(noexcept(P{} + P{} * P{} - P{} / P{}))
-        : YearMonthDay(time_point<P>(sd.time_since_epoch())) {
-    }
+        [[nodiscard]] constexpr bool ok() const noexcept {
+            return month_.ok();
+        }
 
-    [[nodiscard]] constexpr Year year() const noexcept {
-        return year_;
-    }
+        friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::years d) noexcept {
+            return YearMonth{ym.year_ + d, ym.month_};
+        }
+        friend constexpr YearMonth operator+(std::chrono::years d, YearMonth const &ym) noexcept {
+            return YearMonth{ym.year_ + d, ym.month_};
+        }
 
-    [[nodiscard]] constexpr Month month() const noexcept {
-        return month_;
-    }
+        constexpr YearMonth &operator+=(std::chrono::years d) noexcept {
+            *this = *this + d;
+            return *this;
+        }
 
-    [[nodiscard]] constexpr Day day() const noexcept {
-        return day_;
-    }
+        // TODO overflow
+        friend constexpr YearMonth operator+(YearMonth const &ym, std::chrono::months d) noexcept {
+            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
+        }
+        friend constexpr YearMonth operator+(std::chrono::months d, YearMonth const &ym) noexcept {
+            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count());
+        }
 
-    [[nodiscard]] constexpr time_point<boost::multiprecision::checked_int128_t> to_time_point() const {
-        static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
-        static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-        static_assert(std::numeric_limits<boost::multiprecision::checked_int128_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
-        boost::multiprecision::checked_int128_t y = static_cast<int64_t>(year_);
-        auto m = static_cast<unsigned int>(month_);
-        auto d = static_cast<unsigned int>(day_);
-        y -= m <= 2;
-        boost::multiprecision::checked_int128_t const era = (y >= 0 ? y : y - 399) / 400;
-        auto const yoe = static_cast<unsigned>(y - era * 400);                 // [0, 399]
-        unsigned const doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;  // [0, 365]
-        unsigned const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;            // [0, 146096]
-        // note that the epoch of system_clock is specified as 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970
-        return time_point<boost::multiprecision::checked_int128_t>{typename time_point<boost::multiprecision::checked_int128_t>::duration{era * 146097 + static_cast<boost::multiprecision::checked_int128_t>(doe) - 719468}};
-    }
-    [[nodiscard]] constexpr time_point_local<boost::multiprecision::checked_int128_t> to_time_point_local() const{
-        return time_point_local<boost::multiprecision::checked_int128_t>{to_time_point().time_since_epoch()};
-    }
+        constexpr YearMonth &operator+=(std::chrono::months d) noexcept {
+            *this = *this + d;
+            return *this;
+        }
 
-    [[nodiscard]] constexpr bool ok() const noexcept {
-        return month_.ok() && day_.ok() && day_ <= last_day_in_month(year_, month_);
-    }
+        friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::years d) noexcept {
+            return {ym.year_ - d, ym.month_};
+        }
+        friend constexpr YearMonth operator-(YearMonth const &ym, std::chrono::months d) noexcept {
+            return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) - d.count());
+        }
 
-    constexpr auto operator<=>(YearMonthDay const &) const noexcept = default;
+        friend constexpr std::chrono::months operator-(YearMonth const &a, YearMonth const &b) noexcept {
+            return (a.year_ - b.year_) + (a.month_ - b.month_);
+        }
 
-    friend constexpr YearMonthDay operator+(YearMonthDay const &ym, std::chrono::years d) noexcept {
-        return {ym.year_ + d, ym.month_, ym.day_};
-    }
-    friend constexpr YearMonthDay operator+(std::chrono::years d, YearMonthDay const &ym) noexcept {
-        return {ym.year_ + d, ym.month_, ym.day_};
-    }
+        constexpr YearMonth &operator-=(std::chrono::years d) noexcept {
+            *this = *this - d;
+            return *this;
+        }
+        constexpr YearMonth &operator-=(std::chrono::months d) noexcept {
+            *this = *this - d;
+            return *this;
+        }
+    };
 
-    constexpr YearMonthDay & operator+=(std::chrono::years d) noexcept {
-        *this = *this + d;
-        return *this;
-    }
+    struct YearMonthDay {
+        template<typename P>
+        using time_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<P, std::chrono::days::period>>;
+        template<typename P>
+        using time_point_local = std::chrono::time_point<std::chrono::local_t, std::chrono::duration<P, std::chrono::days::period>>;
 
-    friend constexpr YearMonthDay operator+(YearMonthDay const &d, std::chrono::months m) noexcept {
-        return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
-    }
-    friend constexpr YearMonthDay operator+(std::chrono::months m, YearMonthDay const &d) noexcept {
-        return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
-    }
+    private:
+        // adapted from https://howardhinnant.github.io/date_algorithms.html
+        Year year_ = Year{0};
+        Month month_ = Month{1};
+        Day day_ = Day{1};
 
-    constexpr YearMonthDay & operator+=(std::chrono::months d) noexcept {
-        *this = *this + d;
-        return *this;
-    }
+        static constexpr std::chrono::day last_day_in_month(Year year, Month month) noexcept {
+            assert(month.ok());
+            constexpr unsigned char common[]{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+            auto m = static_cast<unsigned int>(month);
+            return std::chrono::day{m != 2 || !year.is_leap() ? common[m - 1] : 29u};
+        }
 
-    friend constexpr YearMonthDay operator-(YearMonthDay const &ym, std::chrono::years d) noexcept {
-        return {ym.year_ - d, ym.month_, ym.day_};
-    }
-    friend constexpr YearMonthDay operator-(YearMonthDay const &d, std::chrono::months m) noexcept {
-        return YearMonthDay{YearMonth{d.year_, d.month_} - m, d.day_};
-    }
+    public:
+        constexpr YearMonthDay() noexcept = default;
 
-    constexpr YearMonthDay & operator-=(std::chrono::years d) noexcept {
-        *this = *this - d;
-        return *this;
-    }
-    constexpr YearMonthDay & operator-=(std::chrono::months d) noexcept {
-        *this = *this - d;
-        return *this;
-    }
-};
+        constexpr explicit YearMonthDay(std::chrono::year_month_day ymd) noexcept
+            : year_(static_cast<int>(ymd.year())), month_(ymd.month()), day_(ymd.day()) {
+        }
+        constexpr YearMonthDay(Year const &y, Month m, std::chrono::day d) noexcept
+            : year_(y), month_(m), day_(d) {
+        }
+        constexpr YearMonthDay(Year const &y, Month m, std::chrono::last_spec) noexcept
+            : year_(y), month_(m), day_(last_day_in_month(y, m)) {
+        }
+        constexpr YearMonthDay(YearMonth const &ym, Day d) noexcept
+            : year_(ym.year()), month_(ym.month()), day_(d) {
+        }
+        constexpr YearMonthDay(YearMonth const &ym, std::chrono::last_spec) noexcept
+            : YearMonthDay(ym.year(), ym.month(), std::chrono::last) {
+        }
+        template<typename P>
+        static constexpr std::optional<YearMonthDay> from_time_point_checked(time_point<P> sd) noexcept {
+            static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
+            static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
+            static_assert(std::numeric_limits<P>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
+            rdf4cpp::util::CheckedIntegral<P> z = sd.time_since_epoch().count();
+            z += 719468;
+            rdf4cpp::util::CheckedIntegral<P> const era = (z >= 0 ? z : z - 146096) / 146097;
+            rdf4cpp::util::CheckedIntegral<P> const doe = z - era * 146097;                                       // [0, 146096]
+            rdf4cpp::util::CheckedIntegral<P> const yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;  // [0, 399]
+            rdf4cpp::util::CheckedIntegral<P> const y = yoe + era * 400;
+            rdf4cpp::util::CheckedIntegral<P> const doy = doe - (yoe * 365 + yoe / 4 - yoe / 100);  // [0, 365]
+            rdf4cpp::util::CheckedIntegral<P> const mp = (doy * 5 + 2) / 153;                       // [0, 11]
+            rdf4cpp::util::CheckedIntegral<P> const d = doy - (mp * 153 + 2) / 5 + 1;               // [1, 31]
+            rdf4cpp::util::CheckedIntegral<P> const m = mp < 10 ? mp + 3 : mp - 9;                  // [1, 12]
+            auto const y_out = (y + (m <= 2)).template checked_cast<int64_t>();
+            auto const m_out = m.template checked_cast<unsigned>();
+            auto const d_out = d.template checked_cast<unsigned>();
+            if (y_out.is_invalid() || m_out.is_invalid() || d_out.is_invalid()) {
+                return std::nullopt;
+            }
+            return YearMonthDay{Year{y_out.get_value()}, std::chrono::month{m_out.get_value()}, std::chrono::day{d_out.get_value()}};
+        }
+        template<typename P>
+        static constexpr std::optional<YearMonthDay> from_local_time_point_checked(time_point_local<P> sd) noexcept {
+            return from_time_point_checked(time_point<P>(sd.time_since_epoch()));
+        }
+        template<typename P>
+        constexpr explicit YearMonthDay(time_point<P> sd) : YearMonthDay(from_time_point_checked(sd).value()) {
+        }
+        template<typename P>
+        constexpr explicit YearMonthDay(time_point_local<P> sd) : YearMonthDay(from_local_time_point_checked(sd).value()) {
+        }
 
-using DurationNano = std::chrono::duration<boost::multiprecision::checked_int128_t, std::chrono::nanoseconds::period>;
-using TimePoint = std::chrono::time_point<std::chrono::local_t, DurationNano>;
-// system_clock does not use leap seconds, as required by rdf (xsd)
-using TimePointSys = std::chrono::time_point<std::chrono::system_clock, DurationNano>;
-using ZonedTime = std::chrono::zoned_time<DurationNano, Timezone>;
+        [[nodiscard]] constexpr Year year() const noexcept {
+            return year_;
+        }
 
-namespace util {
+        [[nodiscard]] constexpr Month month() const noexcept {
+            return month_;
+        }
 
-// see https://www.w3.org/TR/xpath-functions/#comp.datetime
-inline constexpr YearMonthDay time_point_replacement_date{Year(1972), std::chrono::January, std::chrono::day{1}};
-inline constexpr DurationNano time_point_replacement_time_of_day{0};
-// implementation defined, not from standard
-inline constexpr Timezone time_point_replacement_timezone{std::chrono::minutes{0}};
+        [[nodiscard]] constexpr Day day() const noexcept {
+            return day_;
+        }
 
-constexpr TimePoint construct_timepoint(YearMonthDay const &date, const DurationNano& time_of_day) {
-    auto sd = date.to_time_point_local();
-    auto ms = static_cast<TimePoint>(sd);
-    ms += time_of_day;
-    return ms;
-}
+        [[nodiscard]] constexpr std::optional<time_point<util::Int128>> to_time_point() const {
+            static_assert(std::numeric_limits<unsigned>::digits >= 18, "This algorithm has not been ported to a 16 bit unsigned integer");
+            static_assert(std::numeric_limits<int64_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
+            static_assert(std::numeric_limits<boost::multiprecision::checked_int128_t>::digits >= 20, "This algorithm has not been ported to a 16 bit signed integer");
+            util::CheckedIntegral<util::Int128> y = static_cast<int64_t>(year_);
+            auto m = static_cast<unsigned int>(month_);
+            auto d = static_cast<unsigned int>(day_);
+            y -= m <= 2;
+            util::CheckedIntegral<util::Int128> const era = (y >= 0 ? y : y - 399) / 400;
+            auto const yoe = y - era * 400;                                    // [0, 399]
+            auto const doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;  // [0, 365]
+            auto const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;            // [0, 146096]
+            // note that the epoch of system_clock is specified as 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970
+            time_point<util::CheckedIntegral<util::Int128>> const r{typename time_point<util::CheckedIntegral<util::Int128>>::duration{era * 146097 + static_cast<util::CheckedIntegral<util::Int128>>(doe) - 719468}};
+            return util::from_checked(r);
+        }
+        [[nodiscard]] constexpr std::optional<time_point_local<util::Int128>> to_time_point_local() const {
+            auto const v = to_time_point();
+            return time_point_local<util::Int128>{v.value().time_since_epoch()};
+        }
 
-constexpr std::pair<YearMonthDay, DurationNano> deconstruct_timepoint(TimePoint const &tp) {
-    auto days = std::chrono::floor<std::chrono::duration<DurationNano::rep, std::chrono::days::period>>(tp);
-    return {YearMonthDay{days}, tp - days};
-}
+        [[nodiscard]] constexpr bool ok() const noexcept {
+            return month_.ok() && day_.ok() && day_ <= last_day_in_month(year_, month_);
+        }
 
-} // namespace util
+        constexpr auto operator<=>(YearMonthDay const &) const noexcept = default;
+
+        friend constexpr YearMonthDay operator+(YearMonthDay const &ym, std::chrono::years d) noexcept {
+            return {ym.year_ + d, ym.month_, ym.day_};
+        }
+        friend constexpr YearMonthDay operator+(std::chrono::years d, YearMonthDay const &ym) noexcept {
+            return {ym.year_ + d, ym.month_, ym.day_};
+        }
+
+        constexpr YearMonthDay &operator+=(std::chrono::years d) noexcept {
+            *this = *this + d;
+            return *this;
+        }
+
+        friend constexpr YearMonthDay operator+(YearMonthDay const &d, std::chrono::months m) noexcept {
+            return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
+        }
+        friend constexpr YearMonthDay operator+(std::chrono::months m, YearMonthDay const &d) noexcept {
+            return YearMonthDay{YearMonth{d.year_, d.month_} + m, d.day_};
+        }
+
+        constexpr YearMonthDay &operator+=(std::chrono::months d) noexcept {
+            *this = *this + d;
+            return *this;
+        }
+
+        friend constexpr YearMonthDay operator-(YearMonthDay const &ym, std::chrono::years d) noexcept {
+            return {ym.year_ - d, ym.month_, ym.day_};
+        }
+        friend constexpr YearMonthDay operator-(YearMonthDay const &d, std::chrono::months m) noexcept {
+            return YearMonthDay{YearMonth{d.year_, d.month_} - m, d.day_};
+        }
+
+        constexpr YearMonthDay &operator-=(std::chrono::years d) noexcept {
+            *this = *this - d;
+            return *this;
+        }
+        constexpr YearMonthDay &operator-=(std::chrono::months d) noexcept {
+            *this = *this - d;
+            return *this;
+        }
+    };
+
+    using DurationNano = std::chrono::duration<util::Int128, std::chrono::nanoseconds::period>;
+    using TimePoint = std::chrono::time_point<std::chrono::local_t, DurationNano>;
+    // system_clock does not use leap seconds, as required by rdf (xsd)
+    using TimePointSys = std::chrono::time_point<std::chrono::system_clock, DurationNano>;
+    using ZonedTime = std::chrono::zoned_time<DurationNano, Timezone>;
+
+    namespace util {
+        using DurationNano_Checked = std::chrono::duration<util::CheckedIntegral<util::Int128>, std::chrono::nanoseconds::period>;
+        using TimePoint_Checked = std::chrono::time_point<std::chrono::local_t, DurationNano_Checked>;
+        using TimePointSys_Checked = std::chrono::time_point<std::chrono::system_clock, DurationNano_Checked>;
+        using ZonedTime_Checked = std::chrono::zoned_time<DurationNano_Checked, Timezone>;
+
+        // see https://www.w3.org/TR/xpath-functions/#comp.datetime
+        inline constexpr YearMonthDay time_point_replacement_date{Year(1972), std::chrono::January, std::chrono::day{1}};
+        inline constexpr DurationNano time_point_replacement_time_of_day{0};
+        // implementation defined, not from standard
+        inline constexpr Timezone time_point_replacement_timezone{std::chrono::minutes{0}};
+
+        // TODO check return values
+        constexpr std::optional<TimePoint> construct_timepoint(YearMonthDay const &date, DurationNano const &time_of_day) noexcept {
+            auto sd = date.to_time_point_local();
+            if (!sd.has_value()) {
+                return std::nullopt;
+            }
+            auto ms = static_cast<TimePoint_Checked>(to_checked(*sd));
+            ms += time_of_day;
+            return from_checked(ms);
+        }
+
+        // TODO check return values
+        constexpr std::optional<std::pair<YearMonthDay, DurationNano>> deconstruct_timepoint(TimePoint const &tp) noexcept {
+            auto const days = std::chrono::floor<std::chrono::duration<DurationNano_Checked::rep, std::chrono::days::period>>(to_checked(tp));
+            if (days.time_since_epoch().count().is_invalid()) {
+                return std::nullopt;
+            }
+            auto const h = tp - days;
+            if (h.count().is_invalid()) {
+                return std::nullopt;
+            }
+            auto ymd = YearMonthDay::from_local_time_point_checked(*from_checked(days));
+            if (!ymd.has_value()) {
+                return std::nullopt;
+            }
+            return std::pair<YearMonthDay, DurationNano>{*ymd, *from_checked(h)};
+        }
+
+    }  // namespace util
 
 }  // namespace rdf4cpp
 
@@ -466,7 +554,7 @@ namespace std::chrono {
             return ::rdf4cpp::Timezone{};
         }
     };
-} // namespace std::chrono
+}  // namespace std::chrono
 
 #ifndef DOXYGEN_PARSER
 template<typename Policy>
@@ -523,7 +611,11 @@ struct std::formatter<rdf4cpp::YearMonth> : std::formatter<std::string_view> {
 template<>
 struct std::formatter<rdf4cpp::TimePoint> : std::formatter<std::string_view> {
     inline auto format(rdf4cpp::TimePoint const &p, format_context &ctx) const {
-        auto [date, time] = rdf4cpp::util::deconstruct_timepoint(p);
+        auto const dc = rdf4cpp::util::deconstruct_timepoint(p);
+        if (!dc.has_value()) {
+            return std::format_to(ctx.out(), "{}", "invalid timepoint");
+        }
+        auto [date, time] = *dc;
         return std::format_to(ctx.out(), "{}T{:%H:%M:%S}", date, std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)});
     }
 };
@@ -547,7 +639,7 @@ namespace rdf4cpp {
         std::format_to(std::ostream_iterator<char, char>{os}, "{}", value);
         return os;
     }
-}
+}  // namespace rdf4cpp
 #endif
 
 #endif  //RDF4CPP_TIMEZONE_HPP

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -611,7 +611,6 @@ namespace rdf4cpp {
             return ms;
         }
 
-        // TODO check return values
         constexpr std::optional<std::pair<YearMonthDay, DurationNano>> deconstruct_timepoint(TimePoint const &tp) noexcept {
             auto const days = std::chrono::floor<std::chrono::duration<DurationNano_Checked::rep, std::chrono::days::period>>(to_checked(tp));
             if (days.time_since_epoch().count().is_invalid()) {

--- a/src/rdf4cpp/Timezone.hpp
+++ b/src/rdf4cpp/Timezone.hpp
@@ -291,7 +291,7 @@ namespace rdf4cpp {
         Month month_ = Month{1};
 
         // returns nullopt iff overflow
-        static constexpr std::optional<YearMonth> create_normalized(util::CheckedIntegral<int64_t> y, util::CheckedIntegral<int64_t> mo) noexcept {
+        static constexpr std::optional<YearMonth> create_normalized(util::CheckedIntegral<Int128> y, util::CheckedIntegral<Int128> mo) noexcept {
             mo -= 1;
             y += mo / 12;
             mo %= 12;
@@ -301,10 +301,11 @@ namespace rdf4cpp {
             }
             mo += 1;
             auto um = mo.checked_cast<unsigned int>();
-            if (y.is_invalid() || um.is_invalid()) {
+            auto uy = y.checked_cast<int64_t>();
+            if (uy.is_invalid() || um.is_invalid()) {
                 return std::nullopt;
             }
-            return YearMonth{Year{y.get_value()}, std::chrono::month{um.get_value()}};
+            return YearMonth{Year{uy.get_value()}, std::chrono::month{um.get_value()}};
         }
 
     public:
@@ -353,7 +354,7 @@ namespace rdf4cpp {
             return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) + d.count()).value();
         }
         [[nodiscard]] constexpr std::optional<YearMonth> add_checked(std::chrono::months d) const noexcept {
-            return create_normalized(static_cast<int64_t>(year_), util::CheckedIntegral<int64_t>(static_cast<unsigned int>(month_)) + d.count());
+            return create_normalized(static_cast<int64_t>(year_), util::CheckedIntegral<Int128>(static_cast<unsigned int>(month_)) + d.count());
         }
 
         constexpr YearMonth &operator+=(std::chrono::months d) noexcept {
@@ -375,7 +376,7 @@ namespace rdf4cpp {
             return create_normalized(static_cast<int64_t>(ym.year_), static_cast<unsigned int>(ym.month_) - d.count()).value();
         }
         [[nodiscard]] constexpr std::optional<YearMonth> sub_checked(std::chrono::months d) const noexcept {
-            return create_normalized(static_cast<int64_t>(year_), util::CheckedIntegral<int64_t>(static_cast<unsigned int>(month_)) - d.count());
+            return create_normalized(static_cast<int64_t>(year_), util::CheckedIntegral<Int128>(static_cast<unsigned int>(month_)) - d.count());
         }
 
         friend constexpr std::chrono::months operator-(YearMonth const &a, YearMonth const &b) noexcept {

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -119,10 +119,6 @@ F from_chars(std::string_view s) {
     }();
     static_assert(max_pow10 == 10'000'000'000'000'000'000ull);
 
-    if (s == "-170141183460469231731687303715884105728") {
-        return std::numeric_limits<__int128>::min();
-    }
-
     bool neg = false;
     if (s.starts_with('+')) {
         s.remove_prefix(1);
@@ -146,19 +142,18 @@ F from_chars(std::string_view s) {
             s = s.substr(0, pos);
         }
         __int128 value2 = from_chars<uint64_t, datatype>(p);
+        if (neg) {
+            value2 = -value2;
+        }
         for (int j = 0; j < i; ++j) {
-            if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value2, max_pow10, value2)) {
+            if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value2, max_pow10, value2)) [[unlikely]] {
                 throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
             }
         }
-        if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value, value2, value)) {
+        if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value, value2, value)) [[unlikely]] {
             throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
         }
         ++i;
-    }
-
-    if (neg) {
-        value = -value;
     }
     return value;
 }

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -87,6 +87,25 @@ F from_chars(std::string_view s) {
 
     return value;
 }
+
+template<typename F, ConstexprString datatype>
+requires std::same_as<F, boost::multiprecision::checked_int128_t>
+F from_chars(std::string_view s) {
+    if (s.starts_with('+')) {
+        s.remove_prefix(1);
+    }
+    if (auto const pos = s.find_first_not_of('0'); pos != std::string::npos) {
+        s.remove_prefix(pos);
+    }
+
+    try {
+        return F{s};
+    }
+    catch (std::runtime_error const &e) {
+        throw InvalidNode{std::format("{} parsing error: {}", datatype, e.what())};
+    }
+}
+
 #ifdef __SIZEOF_INT128__
 template<typename F, ConstexprString datatype>
 requires std::same_as<F, __int128>

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -88,8 +88,7 @@ F from_chars(std::string_view s) {
     return value;
 }
 
-template<typename F, ConstexprString datatype>
-requires std::same_as<F, boost::multiprecision::checked_int128_t>
+template<rdf4cpp::util::detail::BoostNumber F, ConstexprString datatype>
 F from_chars(std::string_view s) {
     if (s.starts_with('+')) {
         s.remove_prefix(1);

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -10,6 +10,7 @@
 #include <format>
 
 #include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp::datatypes::registry::util {
 /**
@@ -86,6 +87,40 @@ F from_chars(std::string_view s) {
 
     return value;
 }
+#ifdef __SIZEOF_INT128__
+template<typename F, ConstexprString datatype>
+requires std::same_as<F, __int128>
+F from_chars(std::string_view s) {
+    bool neg = false;
+    if (s.starts_with('+')) {
+        s.remove_prefix(1);
+    }
+    else if(s.starts_with('-')) {
+        neg = true;
+        s.remove_prefix(1);
+    }
+
+    __int128 r = 0;
+
+    for (char c : s) {
+        if (c > '9' || c < '0') {
+            throw rdf4cpp::InvalidNode{std::format("{} parsing error: found {}, invalid for datatype", datatype, c)};
+        }
+        __int128 n = c - '0';
+        if (neg) {
+            n = -n;
+        }
+        if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, __int128{10}, r)) {
+            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
+        }
+        if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, n, r)) {
+            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
+        }
+    }
+
+    return r;
+}
+#endif
 
 namespace detail  {
 /**

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -147,11 +147,11 @@ F from_chars(std::string_view s) {
         __int128 value2 = from_chars<uint64_t, datatype>(p);
         for (int j = 0; j < i; ++j) {
             if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value2, max_pow10, value2)) {
-                throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
+                throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow mul", datatype)};
             }
         }
         if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value, value2, value)) {
-            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
+            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow add", datatype)};
         }
         ++i;
     }

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -109,6 +109,19 @@ F from_chars(std::string_view s) {
 template<typename F, ConstexprString datatype>
 requires std::same_as<F, __int128>
 F from_chars(std::string_view s) {
+    static constexpr __int128 max_pow10 = []() {
+        auto n = std::numeric_limits<uint64_t>::digits10;
+        __int128 d = 1;
+        for (int i = 0; i < n; ++i) {
+            d = d * 10;
+        }
+        return d;
+    }();
+
+    if (s == "-170141183460469231731687303715884105728") {
+        return std::numeric_limits<__int128>::min();
+    }
+
     bool neg = false;
     if (s.starts_with('+')) {
         s.remove_prefix(1);
@@ -118,25 +131,35 @@ F from_chars(std::string_view s) {
         s.remove_prefix(1);
     }
 
-    __int128 r = 0;
-
-    for (char c : s) {
-        if (c > '9' || c < '0') {
-            throw rdf4cpp::InvalidNode{std::format("{} parsing error: found {}, invalid for datatype", datatype, c)};
+    __int128 value = 0;
+    int i = 0;
+    while (!s.empty()) {
+        std::string_view p;
+        if (s.size() <= std::numeric_limits<uint64_t>::digits10) {
+            p = s;
+            s = "";
         }
-        __int128 n = c - '0';
-        if (neg) {
-            n = -n;
+        else {
+            const size_t pos = s.size() - std::numeric_limits<uint64_t>::digits10;
+            p = s.substr(pos);
+            s = s.substr(0, pos);
         }
-        if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, __int128{10}, r)) {
+        __int128 value2 = from_chars<uint64_t, datatype>(p);
+        for (int j = 0; j < i; ++j) {
+            if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value2, max_pow10, value2)) {
+                throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
+            }
+        }
+        if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value, value2, value)) {
             throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
         }
-        if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, n, r)) {
-            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
-        }
+        ++i;
     }
 
-    return r;
+    if (neg) {
+        value = -value;
+    }
+    return value;
 }
 #endif
 

--- a/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/CharConvExt.hpp
@@ -117,6 +117,7 @@ F from_chars(std::string_view s) {
         }
         return d;
     }();
+    static_assert(max_pow10 == 10'000'000'000'000'000'000ull);
 
     if (s == "-170141183460469231731687303715884105728") {
         return std::numeric_limits<__int128>::min();
@@ -147,11 +148,11 @@ F from_chars(std::string_view s) {
         __int128 value2 = from_chars<uint64_t, datatype>(p);
         for (int j = 0; j < i; ++j) {
             if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value2, max_pow10, value2)) {
-                throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow mul", datatype)};
+                throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
             }
         }
         if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(value, value2, value)) {
-            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow add", datatype)};
+            throw rdf4cpp::InvalidNode{std::format("{} parsing error: overflow", datatype)};
         }
         ++i;
     }

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -247,32 +247,34 @@ namespace rdf4cpp::datatypes::registry::util {
     static_assert(number_of_digits(9) == 1);
     static_assert(number_of_digits(-1) == 2);
     static_assert(number_of_digits(10) == 2);
-    static_assert(number_of_digits(std::numeric_limits<uint64_t>::max()) == std::numeric_limits<uint64_t>::digits10 + 1);
+    static_assert(number_of_digits(std::numeric_limits<int64_t>::max()) == std::numeric_limits<int64_t>::digits10 + 1);
     namespace chrono_max_canonical_string_chars {
-        // TODO check limits
-        inline constexpr size_t year = std::numeric_limits<uint64_t>::digits10 + 2;  // +1 for the not fully representable digit, +1 for - sign
+        inline constexpr size_t year = std::numeric_limits<int64_t>::digits10 + 2;  // +1 for the not fully representable digit, +1 for - sign
         //std::chrono::day is in [0, 255]
         inline constexpr size_t day = number_of_digits(255);
         //std::chrono::month is in [0, 255]
         inline constexpr size_t month = number_of_digits(255);
+        // not including leading 0.
+        inline constexpr size_t sub_seconds = number_of_digits(std::chrono::nanoseconds::period::den) - 1;
+        static_assert(std::chrono::nanoseconds::period::num == 1);
         //[0, 59.999...] (includes nanoseconds)
-        inline constexpr size_t seconds = 2 + 1 + 9;
+        inline constexpr size_t seconds = number_of_digits(59) + 1 + sub_seconds;
         //[0,59]
-        inline constexpr size_t minutes = 2;
-        //[0,24] (used if more than 24 hours get added to days)
-        inline constexpr size_t hours = 2;
+        inline constexpr size_t minutes = number_of_digits(59);
+        //[0,24]
+        inline constexpr size_t hours = number_of_digits(24);
         //used if no days are serialized
-        inline constexpr size_t hours_unbound = number_of_digits(std::chrono::floor<std::chrono::hours>(std::chrono::milliseconds::max()).count());
+        inline constexpr size_t hours_unbound = number_of_digits(std::chrono::floor<std::chrono::hours>(std::chrono::nanoseconds::max()).count());
         static_assert(sizeof(std::chrono::hours::rep) <= sizeof(int64_t));
-        static_assert(sizeof(std::chrono::milliseconds ::rep) <= sizeof(int64_t));
+        static_assert(sizeof(std::chrono::nanoseconds::rep) <= sizeof(int64_t));
         //duration
         static constexpr size_t years = number_of_digits(std::chrono::floor<std::chrono::years>(std::chrono::months::max()).count());
         static_assert(sizeof(std::chrono::years::rep) <= sizeof(int64_t));
         static_assert(sizeof(std::chrono::months::rep) <= sizeof(int64_t));
+        //duration [1,12]
+        inline constexpr size_t months = number_of_digits(12);
         //duration
-        inline constexpr size_t months = 2;
-        //duration
-        inline constexpr size_t days = number_of_digits(std::chrono::floor<std::chrono::days>(std::chrono::milliseconds::max()).count());
+        inline constexpr size_t days = number_of_digits(std::chrono::floor<std::chrono::days>(std::chrono::nanoseconds::max()).count());
         static_assert(sizeof(std::chrono::days::rep) <= sizeof(int64_t));
     };  // namespace chrono_max_canonical_string_chars
 

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -6,10 +6,10 @@
 #include <string_view>
 
 #include <dice/hash.hpp>
+#include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/Timezone.hpp>
 #include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 #include <rdf4cpp/util/CheckedInt.hpp>
-#include <rdf4cpp/Timezone.hpp>
-#include <rdf4cpp/InvalidNode.hpp>
 
 /**
  * @file
@@ -18,291 +18,292 @@
  */
 
 namespace rdf4cpp::datatypes::registry::util {
-template<typename ResultType, typename ParsingType, char Separator, ConstexprString datatype>
-ResultType parse_date_time_fragment(std::string_view &s) {
-    std::string_view res_s = s;
-    if constexpr (Separator != '\0') {
-        auto p = s.find(Separator, 1);
+    template<typename ResultType, typename ParsingType, char Separator, ConstexprString datatype>
+    ResultType parse_date_time_fragment(std::string_view &s) {
+        std::string_view res_s = s;
+        if constexpr (Separator != '\0') {
+            auto p = s.find(Separator, 1);
+            if (p == std::string::npos)
+                throw InvalidNode(std::format("{} parse error: missing {}", datatype, Separator));
+            res_s = s.substr(0, p);
+            s = s.substr(p + 1);
+        }
+        return ResultType{from_chars<ParsingType, datatype>(res_s)};
+    }
+
+    template<typename ResultType, typename ParsingType, char Separator, ConstexprString datatype>
+    std::optional<ResultType> parse_duration_fragment(std::string_view &s) {
+        if (s.empty())
+            return std::nullopt;
+        std::string_view res_s = s;
+        auto p = s.find(Separator);
         if (p == std::string::npos)
-            throw InvalidNode(std::format("{} parse error: missing {}", datatype, Separator));
+            return std::nullopt;
         res_s = s.substr(0, p);
         s = s.substr(p + 1);
+        return ResultType{from_chars<ParsingType, datatype>(res_s)};
     }
-    return ResultType{from_chars<ParsingType, datatype>(res_s)};
-}
 
-template<typename ResultType, typename ParsingType, char Separator, ConstexprString datatype>
-std::optional<ResultType> parse_duration_fragment(std::string_view &s) {
-    if (s.empty())
-        return std::nullopt;
-    std::string_view res_s = s;
-    auto p = s.find(Separator);
-    if (p == std::string::npos)
-        return std::nullopt;
-    res_s = s.substr(0, p);
-    s = s.substr(p + 1);
-    return ResultType{from_chars<ParsingType, datatype>(res_s)};
-}
-
-template<ConstexprString datatype>
-inline std::chrono::nanoseconds parse_nanoseconds(std::string_view s) {
-    auto p = s.find('.');
-    std::chrono::nanoseconds ms{};
-    if (p != std::string::npos) {
-        auto milli_s = s.substr(p + 1, 9);
-        ms = std::chrono::nanoseconds{from_chars<unsigned int, datatype>(milli_s)};
-        for (size_t i = milli_s.length(); i < 9; ++i) {
-            ms *= 10;
+    template<ConstexprString datatype>
+    inline std::chrono::nanoseconds parse_nanoseconds(std::string_view s) {
+        auto p = s.find('.');
+        std::chrono::nanoseconds ms{};
+        if (p != std::string::npos) {
+            auto milli_s = s.substr(p + 1, 9);
+            ms = std::chrono::nanoseconds{from_chars<unsigned int, datatype>(milli_s)};
+            for (size_t i = milli_s.length(); i < 9; ++i) {
+                ms *= 10;
+            }
+            s = s.substr(0, p);
         }
-        s = s.substr(0, p);
+        std::chrono::seconds sec{from_chars<unsigned int, datatype>(s)};
+        return sec + ms;
     }
-    std::chrono::seconds sec{from_chars<unsigned int, datatype>(s)};
-    return sec + ms;
-}
 
-template<ConstexprString datatype>
-inline std::optional<std::chrono::nanoseconds> parse_duration_nanoseconds(std::string_view &s) {
-    if (s.empty()) {
-        return std::nullopt;
+    template<ConstexprString datatype>
+    inline std::optional<std::chrono::nanoseconds> parse_duration_nanoseconds(std::string_view &s) {
+        if (s.empty()) {
+            return std::nullopt;
+        }
+        std::string_view res_s = s;
+        auto p = s.find('S');
+        if (p == std::string::npos) {
+            return std::nullopt;
+        }
+        res_s = s.substr(0, p);
+        s = s.substr(p + 1);
+        return parse_nanoseconds<datatype>(res_s);
     }
-    std::string_view res_s = s;
-    auto p = s.find('S');
-    if (p == std::string::npos) {
-        return std::nullopt;
-    }
-    res_s = s.substr(0, p);
-    s = s.substr(p + 1);
-    return parse_nanoseconds<datatype>(res_s);
-}
 
-inline char *canonical_seconds_remove_empty_millis(char *it) {
-    for (size_t m = 0; m<9; ++m) {
-        if (*(it - 1) != '0')
-            return it;
+    inline char *canonical_seconds_remove_empty_millis(char *it) {
+        for (size_t m = 0; m < 9; ++m) {
+            if (*(it - 1) != '0')
+                return it;
+            --it;
+        }
+        assert(*(it - 1) == '.');
         --it;
+        return it;
     }
-    assert(*(it - 1) == '.');
-    --it;
-    return it;
-}
 
-template<typename T>
-inline nonstd::expected<T, datatypes::DynamicError> optional_to_overflow(std::optional<T> const &o) {
-    if (o.has_value()) {
-        return *o;
-    } else {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    template<typename T>
+    inline nonstd::expected<T, datatypes::DynamicError> optional_to_overflow(std::optional<T> const &o) {
+        if (o.has_value()) {
+            return *o;
+        } else {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
     }
-}
 
-/**
+    /**
  * returns nullopt on overflow
  * @param tp
  * @param d
  * @return
  */
-inline nonstd::expected<TimePoint, datatypes::DynamicError> add_duration_to_date_time(TimePoint const &tp, std::pair<std::chrono::months, std::chrono::nanoseconds> d) noexcept {
-    auto dec_tp = rdf4cpp::util::deconstruct_timepoint(tp);
-    if (!dec_tp.has_value()) {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    inline nonstd::expected<TimePoint, datatypes::DynamicError> add_duration_to_date_time(TimePoint const &tp, std::pair<std::chrono::months, std::chrono::nanoseconds> d) noexcept {
+        auto dec_tp = rdf4cpp::util::deconstruct_timepoint(tp);
+        if (!dec_tp.has_value()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
+        auto [ymd, time] = *dec_tp;
+
+        using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::util::Int128>;
+
+        Checked checked_m = static_cast<unsigned int>(ymd.month());
+        checked_m += Checked{static_cast<int64_t>(ymd.year())} * 12;
+        checked_m += d.first.count();
+
+        auto const checked_y = (checked_m - 1) / 12;
+
+        checked_m = abs(checked_m - 1);
+
+        auto const y_casted = checked_y.checked_cast<int64_t>();
+        if (y_casted.is_invalid()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
+
+        auto const y = Year{y_casted.get_value()};
+
+        auto const m_casted = (checked_m % 12 + 1).checked_cast<unsigned int>();
+        if (m_casted.is_invalid()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
+        auto const m = std::chrono::month{m_casted.get_value()};
+
+        ymd = YearMonthDay{y, m, ymd.day()};
+        if (!ymd.ok()) {
+            ymd = YearMonthDay{ymd.year(), ymd.month(), std::chrono::last};
+        }
+
+        auto date_opt = ymd.to_time_point_local();
+        if (!date_opt.has_value()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
+        rdf4cpp::util::TimePoint_Checked date = *date_opt;
+        date += time;
+        date += d.second;
+
+        auto date_uc = rdf4cpp::util::from_checked(date);
+        if (!date_uc.has_value()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
+
+        auto const deconstructed = rdf4cpp::util::deconstruct_timepoint(*date_uc);
+        if (!deconstructed.has_value()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+        }
+
+        return *date_uc;
     }
-    auto [ymd, time] = *dec_tp;
 
-    using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::util::Int128>;
-
-    Checked checked_m = static_cast<unsigned int>(ymd.month());
-    checked_m += Checked{static_cast<int64_t>(ymd.year())} * 12;
-    checked_m += d.first.count();
-
-    auto const checked_y = (checked_m -1 ) / 12;
-
-    checked_m = abs(checked_m - 1);
-
-    auto const y_casted = checked_y.checked_cast<int64_t>();
-    if (y_casted.is_invalid()) {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    inline rdf4cpp::util::ZonedTime_Checked apply_tz_checked(TimePoint tp, OptionalTimezone tz) {
+        return {tz.has_value() ? *tz : rdf4cpp::util::time_point_replacement_timezone, rdf4cpp::util::to_checked(tp)};
+    }
+    inline rdf4cpp::util::ZonedTime_Checked apply_tz_checked(std::pair<TimePoint, OptionalTimezone> const &tp) {
+        return apply_tz_checked(tp.first, tp.second);
     }
 
-    auto const y = Year{y_casted.get_value()};
+    inline nonstd::expected<std::chrono::nanoseconds, DynamicError> timepoint_sub(std::pair<TimePoint, OptionalTimezone> const &lhs, std::pair<TimePoint, OptionalTimezone> const &rhs) noexcept {
+        rdf4cpp::util::ZonedTime_Checked const this_tp = apply_tz_checked(lhs);
+        rdf4cpp::util::ZonedTime_Checked const other_tp = apply_tz_checked(rhs);
 
-    auto const m_casted = (checked_m % 12 + 1).checked_cast<unsigned int>();
-    if (m_casted.is_invalid()) {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
-    }
-    auto const m = std::chrono::month{m_casted.get_value()};
-
-    ymd = YearMonthDay{y, m, ymd.day()};
-    if (!ymd.ok()) {
-        ymd = YearMonthDay{ymd.year(), ymd.month(), std::chrono::last};
+        auto d = this_tp.get_sys_time() - other_tp.get_sys_time();
+        return util::optional_to_overflow(rdf4cpp::util::from_checked(std::chrono::duration_cast<std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, std::chrono::nanoseconds::period>>(d)));
     }
 
-    auto date_opt = ymd.to_time_point_local();
-    if (!date_opt.has_value()) {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    inline static std::partial_ordering compare_time_points(rdf4cpp::TimePoint const &a, std::optional<rdf4cpp::Timezone> atz,
+                                                            rdf4cpp::TimePoint const &b, std::optional<rdf4cpp::Timezone> btz) noexcept {
+        auto const a_sys = apply_tz_checked(a, atz).get_sys_time();
+        auto const b_sys = apply_tz_checked(b, btz).get_sys_time();
+        if (a_sys.time_since_epoch().count().is_invalid() || b_sys.time_since_epoch().count().is_invalid()) {
+            return std::partial_ordering::unordered;
+        }
+        return a_sys <=> b_sys;
     }
-    rdf4cpp::util::TimePoint_Checked date = *date_opt;
-    date += time;
-    date += d.second;
-
-    auto date_uc = rdf4cpp::util::from_checked(date);
-    if (!date_uc.has_value()) {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    template<typename T>
+    requires std::same_as<T, nonstd::expected<TimePoint, datatypes::DynamicError>> || std::same_as<T, std::optional<TimePoint>>
+    inline static std::partial_ordering compare_time_points(T const &a, std::optional<rdf4cpp::Timezone> atz,
+                                                            T const &b, std::optional<rdf4cpp::Timezone> btz) noexcept {
+        if (!a.has_value() || !b.has_value()) {
+            return std::partial_ordering::unordered;
+        }
+        return compare_time_points(*a, atz, *b, btz);
     }
-
-    auto const deconstructed = rdf4cpp::util::deconstruct_timepoint(*date_uc);
-    if (!deconstructed.has_value()) {
-        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    template<std::unsigned_integral T>
+    constexpr T number_of_bits(T x) noexcept {
+        return x < 2 ? x : 1 + number_of_bits(x >> 1);
     }
-
-    return *date_uc;
-}
-
-inline rdf4cpp::util::ZonedTime_Checked apply_tz_checked(TimePoint tp, OptionalTimezone tz) {
-    return {tz.has_value() ? *tz : rdf4cpp::util::time_point_replacement_timezone, rdf4cpp::util::to_checked(tp)};
-}
-inline rdf4cpp::util::ZonedTime_Checked apply_tz_checked(std::pair<TimePoint, OptionalTimezone> const &tp) {
-    return apply_tz_checked(tp.first, tp.second);
-}
-
-inline nonstd::expected<std::chrono::nanoseconds, DynamicError> timepoint_sub(std::pair<TimePoint, OptionalTimezone> const &lhs, std::pair<TimePoint, OptionalTimezone> const &rhs) noexcept {
-    rdf4cpp::util::ZonedTime_Checked const this_tp = apply_tz_checked(lhs);
-    rdf4cpp::util::ZonedTime_Checked const other_tp = apply_tz_checked(rhs);
-
-    auto d = this_tp.get_sys_time() - other_tp.get_sys_time();
-    return util::optional_to_overflow(rdf4cpp::util::from_checked(std::chrono::duration_cast<std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, std::chrono::nanoseconds::period>>(d)));
-}
-
-static inline std::partial_ordering compare_time_points(const rdf4cpp::TimePoint& a, std::optional<rdf4cpp::Timezone> atz,
-                                                        const rdf4cpp::TimePoint& b, std::optional<rdf4cpp::Timezone> btz) noexcept {
-    auto const a_sys = apply_tz_checked(a, atz).get_sys_time();
-    auto const b_sys = apply_tz_checked(b, btz).get_sys_time();
-    if (a_sys.time_since_epoch().count().is_invalid() || b_sys.time_since_epoch().count().is_invalid()) {
-        return std::partial_ordering::unordered;
-    }
-    return a_sys <=> b_sys;
-}
-template<typename T>
-requires std::same_as<T, nonstd::expected<TimePoint, datatypes::DynamicError>> || std::same_as<T, std::optional<TimePoint>>
-inline static std::partial_ordering compare_time_points(T const &a, std::optional<rdf4cpp::Timezone> atz,
-                                                        T const &b, std::optional<rdf4cpp::Timezone> btz) noexcept {
-    if (!a.has_value() || !b.has_value()) {
-        return std::partial_ordering::unordered;
-    }
-    return compare_time_points(*a, atz, *b, btz);
-}
-template<std::unsigned_integral T>
-constexpr T number_of_bits(T x) noexcept {
-    return x < 2 ? x : 1 + number_of_bits(x >> 1);
-}
-template<typename TimeType>
+    template<typename TimeType>
     requires(sizeof(TimeType) <= 2)
-struct __attribute__((__packed__)) InliningHelper {
-    uint16_t tz_offset;
-    TimeType time_value;
+    struct __attribute__((__packed__)) InliningHelper {
+        uint16_t tz_offset;
+        TimeType time_value;
 
-    static constexpr int tz_shift = rdf4cpp::Timezone::max_value().offset.count() + 1;
-    static_assert(number_of_bits(static_cast<unsigned int>(rdf4cpp::Timezone::max_value().offset.count() + tz_shift)) == 11);
+        static constexpr int tz_shift = rdf4cpp::Timezone::max_value().offset.count() + 1;
+        static_assert(number_of_bits(static_cast<unsigned int>(rdf4cpp::Timezone::max_value().offset.count() + tz_shift)) == 11);
 
-    static constexpr uint16_t encode_tz(rdf4cpp::OptionalTimezone tz) noexcept {
-        if (tz.has_value())
-            return static_cast<uint16_t>(tz->offset.count() + tz_shift);
-        else
-            return 0;
+        static constexpr uint16_t encode_tz(rdf4cpp::OptionalTimezone tz) noexcept {
+            if (tz.has_value())
+                return static_cast<uint16_t>(tz->offset.count() + tz_shift);
+            else
+                return 0;
+        }
+
+        constexpr InliningHelper(TimeType t, rdf4cpp::OptionalTimezone tz) noexcept : tz_offset(encode_tz(tz)), time_value(t) {
+        }
+
+        [[nodiscard]] constexpr rdf4cpp::OptionalTimezone decode_tz() const noexcept {
+            if (tz_offset == 0)
+                return std::nullopt;
+            else
+                return rdf4cpp::Timezone{std::chrono::minutes{static_cast<int>(tz_offset) - tz_shift}};
+        }
+    };
+    struct __attribute__((__packed__)) InliningHelperPacked {
+        static constexpr std::size_t width = storage::identifier::LiteralID::width;
+        static constexpr std::size_t tv_width = width - 11;
+
+        uint16_t tz_offset : 11;
+        uint32_t time_value : tv_width;
+
+    private:
+        [[maybe_unused]] uint32_t padding : 64 - width = 0;  // to make sure the rest of the int64 is 0
+
+    public:
+        static constexpr int tz_shift = rdf4cpp::Timezone::max_value().offset.count() + 1;
+        static_assert(number_of_bits(static_cast<unsigned int>(rdf4cpp::Timezone::max_value().offset.count() + tz_shift)) == 11);
+
+        static constexpr uint16_t encode_tz(rdf4cpp::OptionalTimezone tz) noexcept {
+            if (tz.has_value())
+                return static_cast<uint16_t>(tz->offset.count() + tz_shift);
+            else
+                return 0;
+        }
+
+        constexpr InliningHelperPacked(uint32_t t, rdf4cpp::OptionalTimezone tz) noexcept : tz_offset(encode_tz(tz)), time_value(t) {
+        }
+
+        [[nodiscard]] rdf4cpp::OptionalTimezone decode_tz() const noexcept {
+            if (tz_offset == 0)
+                return std::nullopt;
+            else
+                return rdf4cpp::Timezone{std::chrono::minutes{static_cast<int>(tz_offset) - tz_shift}};
+        }
+    };
+
+    inline nonstd::expected<YearMonthDay, datatypes::DynamicError> normalize(YearMonthDay const &i) {
+        // normalize
+        // see https://en.cppreference.com/w/cpp/chrono/year_month_day/operator_days
+        auto t = (i + std::chrono::months{0}).to_time_point();
+        if (!t.has_value()) {
+            return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+        }
+        return util::optional_to_overflow(YearMonthDay::from_time_point_checked(*t));
     }
 
-    constexpr InliningHelper(TimeType t, rdf4cpp::OptionalTimezone tz) noexcept : tz_offset(encode_tz(tz)), time_value(t) {
+    template<std::integral I, I base = 10>
+    consteval I number_of_digits(I num) {
+        if (num < 0) {
+            return 1 + number_of_digits(-num);
+        } else if (num < base) {
+            return 1;
+        } else {
+            return 1 + number_of_digits(num / base);
+        }
     }
-
-    [[nodiscard]] constexpr rdf4cpp::OptionalTimezone decode_tz() const noexcept {
-        if (tz_offset == 0)
-            return std::nullopt;
-        else
-            return rdf4cpp::Timezone{std::chrono::minutes{static_cast<int>(tz_offset) - tz_shift}};
-    }
-};
-struct __attribute__((__packed__)) InliningHelperPacked {
-    static constexpr std::size_t width = storage::identifier::LiteralID::width;
-    static constexpr std::size_t tv_width = width - 11;
-
-    uint16_t tz_offset : 11;
-    uint32_t time_value : tv_width;
-
-private:
-    [[maybe_unused]] uint32_t padding : 64 - width = 0;  // to make sure the rest of the int64 is 0
-
-public:
-    static constexpr int tz_shift = rdf4cpp::Timezone::max_value().offset.count() + 1;
-    static_assert(number_of_bits(static_cast<unsigned int>(rdf4cpp::Timezone::max_value().offset.count() + tz_shift)) == 11);
-
-    static constexpr uint16_t encode_tz(rdf4cpp::OptionalTimezone tz) noexcept {
-        if (tz.has_value())
-            return static_cast<uint16_t>(tz->offset.count() + tz_shift);
-        else
-            return 0;
-    }
-
-    constexpr InliningHelperPacked(uint32_t t, rdf4cpp::OptionalTimezone tz) noexcept : tz_offset(encode_tz(tz)), time_value(t) {
-    }
-
-    [[nodiscard]] rdf4cpp::OptionalTimezone decode_tz() const noexcept {
-        if (tz_offset == 0)
-            return std::nullopt;
-        else
-            return rdf4cpp::Timezone{std::chrono::minutes{static_cast<int>(tz_offset) - tz_shift}};
-    }
-};
-
-inline nonstd::expected<YearMonthDay, datatypes::DynamicError> normalize(YearMonthDay const &i) {
-    // normalize
-    // see https://en.cppreference.com/w/cpp/chrono/year_month_day/operator_days
-    auto t = (i + std::chrono::months{0}).to_time_point();
-    if (!t.has_value()) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
-    }
-    return util::optional_to_overflow(YearMonthDay::from_time_point_checked(*t));
-}
-
-template<std::integral I, I base = 10>
-consteval I number_of_digits(I num) {
-    if (num < 0) {
-        return 1 + number_of_digits(-num);
-    } else if (num < base) {
-        return 1;
-    } else {
-        return 1 + number_of_digits(num / base);
-    }
-}
-static_assert(number_of_digits(0)==1);
-static_assert(number_of_digits(9)==1);
-static_assert(number_of_digits(-1)==2);
-static_assert(number_of_digits(10)==2);
-static_assert(number_of_digits(std::numeric_limits<uint64_t>::max())==std::numeric_limits<uint64_t>::digits10+1);
-namespace chrono_max_canonical_string_chars {
-    inline constexpr size_t year = std::numeric_limits<uint64_t>::digits10 + 2; // +1 for the not fully representable digit, +1 for - sign
-    //std::chrono::day is in [0, 255]
-    inline constexpr size_t day = number_of_digits(255);
-    //std::chrono::month is in [0, 255]
-    inline constexpr size_t month = number_of_digits(255);
-    //[0, 59.999...] (includes nanoseconds)
-    inline constexpr size_t seconds = 2 + 1 + 9;
-    //[0,59]
-    inline constexpr size_t minutes = 2;
-    //[0,24] (used if more than 24 hours get added to days)
-    inline constexpr size_t hours = 2;
-    //used if no days are serialized
-    inline constexpr size_t hours_unbound = number_of_digits(std::chrono::floor<std::chrono::hours>(std::chrono::milliseconds::max()).count());
-    static_assert(sizeof(std::chrono::hours::rep) <= sizeof(int64_t));
-    static_assert(sizeof(std::chrono::milliseconds ::rep) <= sizeof(int64_t));
-    //duration
-    static constexpr size_t years = number_of_digits(std::chrono::floor<std::chrono::years>(std::chrono::months::max()).count());
-    static_assert(sizeof(std::chrono::years::rep) <= sizeof(int64_t));
-    static_assert(sizeof(std::chrono::months::rep) <= sizeof(int64_t));
-    //duration
-    inline constexpr size_t months = 2;
-    //duration
-    inline constexpr size_t days = number_of_digits(std::chrono::floor<std::chrono::days>(std::chrono::milliseconds::max()).count());;
-    static_assert(sizeof(std::chrono::days::rep) <= sizeof(int64_t));
-};
+    static_assert(number_of_digits(0) == 1);
+    static_assert(number_of_digits(9) == 1);
+    static_assert(number_of_digits(-1) == 2);
+    static_assert(number_of_digits(10) == 2);
+    static_assert(number_of_digits(std::numeric_limits<uint64_t>::max()) == std::numeric_limits<uint64_t>::digits10 + 1);
+    namespace chrono_max_canonical_string_chars {
+        inline constexpr size_t year = std::numeric_limits<uint64_t>::digits10 + 2;  // +1 for the not fully representable digit, +1 for - sign
+        //std::chrono::day is in [0, 255]
+        inline constexpr size_t day = number_of_digits(255);
+        //std::chrono::month is in [0, 255]
+        inline constexpr size_t month = number_of_digits(255);
+        //[0, 59.999...] (includes nanoseconds)
+        inline constexpr size_t seconds = 2 + 1 + 9;
+        //[0,59]
+        inline constexpr size_t minutes = 2;
+        //[0,24] (used if more than 24 hours get added to days)
+        inline constexpr size_t hours = 2;
+        //used if no days are serialized
+        inline constexpr size_t hours_unbound = number_of_digits(std::chrono::floor<std::chrono::hours>(std::chrono::milliseconds::max()).count());
+        static_assert(sizeof(std::chrono::hours::rep) <= sizeof(int64_t));
+        static_assert(sizeof(std::chrono::milliseconds ::rep) <= sizeof(int64_t));
+        //duration
+        static constexpr size_t years = number_of_digits(std::chrono::floor<std::chrono::years>(std::chrono::months::max()).count());
+        static_assert(sizeof(std::chrono::years::rep) <= sizeof(int64_t));
+        static_assert(sizeof(std::chrono::months::rep) <= sizeof(int64_t));
+        //duration
+        inline constexpr size_t months = 2;
+        //duration
+        inline constexpr size_t days = number_of_digits(std::chrono::floor<std::chrono::days>(std::chrono::milliseconds::max()).count());
+        ;
+        static_assert(sizeof(std::chrono::days::rep) <= sizeof(int64_t));
+    };  // namespace chrono_max_canonical_string_chars
 
 }  // namespace rdf4cpp::datatypes::registry::util
 

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -96,11 +96,11 @@ namespace rdf4cpp::datatypes::registry::util {
     }
 
     /**
- * returns nullopt on overflow
- * @param tp
- * @param d
- * @return
- */
+     * returns nullopt on overflow
+     * @param tp
+     * @param d
+     * @return
+     */
     inline nonstd::expected<TimePoint, datatypes::DynamicError> add_duration_to_date_time(TimePoint const &tp, std::pair<std::chrono::months, std::chrono::nanoseconds> d) noexcept {
         auto dec_tp = rdf4cpp::util::deconstruct_timepoint(tp);
         if (!dec_tp.has_value()) {
@@ -278,6 +278,7 @@ namespace rdf4cpp::datatypes::registry::util {
     static_assert(number_of_digits(10) == 2);
     static_assert(number_of_digits(std::numeric_limits<uint64_t>::max()) == std::numeric_limits<uint64_t>::digits10 + 1);
     namespace chrono_max_canonical_string_chars {
+        // TODO check limits
         inline constexpr size_t year = std::numeric_limits<uint64_t>::digits10 + 2;  // +1 for the not fully representable digit, +1 for - sign
         //std::chrono::day is in [0, 255]
         inline constexpr size_t day = number_of_digits(255);
@@ -301,7 +302,6 @@ namespace rdf4cpp::datatypes::registry::util {
         inline constexpr size_t months = 2;
         //duration
         inline constexpr size_t days = number_of_digits(std::chrono::floor<std::chrono::days>(std::chrono::milliseconds::max()).count());
-        ;
         static_assert(sizeof(std::chrono::days::rep) <= sizeof(int64_t));
     };  // namespace chrono_max_canonical_string_chars
 

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -18,94 +18,6 @@
  */
 
 namespace rdf4cpp::datatypes::registry::util {
-using CheckedMilliseconds = std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, std::milli>;
-using CheckedMonths = std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, std::ratio<2629746>>;
-static_assert(std::same_as<std::chrono::months::period, CheckedMonths::period>);
-using CheckedTimePoint = std::chrono::time_point<std::chrono::local_t, CheckedMilliseconds>;
-using CheckedZonedTime = std::chrono::zoned_time<CheckedMilliseconds, rdf4cpp::Timezone>;
-using CheckedTimePointSys = std::chrono::time_point<std::chrono::system_clock, CheckedMilliseconds>;
-
-/**
- * turns any duration to its CheckedIntegral counterpart.
- * @tparam R
- * @param v
- * @return
- */
-template<typename R>
-std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, R> to_checked(std::chrono::duration<int64_t, R> v) noexcept {
-    return std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, R>{v.count()};
-}
-/**
- * turns any CheckedIntegral duration back to its integer based duration.
- * @note undefined behavior, if v is invalid
- * @tparam R
- * @param v
- * @return
- */
-template<typename R>
-std::chrono::duration<int64_t, R> from_checked(std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, R> v) noexcept {
-    assert(!v.count().is_invalid());
-    return std::chrono::duration<int64_t, R>{v.count().get_value()};
-}
-/**
- * turns any time_point to its CheckedIntegral counterpart.
- * @tparam C
- * @tparam R
- * @param v
- * @return
- */
-template<typename C, typename R>
-std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, R>> to_checked(std::chrono::time_point<C, std::chrono::duration<int64_t, R>> v) noexcept {
-    return std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, R>>{to_checked(v.time_since_epoch())};
-}
-/**
- * turns any CheckedIntegral time_point back to its integer based time_point.
- * @note undefined behavior, if v is invalid
- * @tparam C
- * @tparam R
- * @param v
- * @return
- */
-template<typename C, typename R>
-std::chrono::time_point<C, std::chrono::duration<int64_t, R>> from_checked(std::chrono::time_point<C, std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, R>> v) noexcept {
-    return std::chrono::time_point<C, std::chrono::duration<int64_t, R>>{from_checked(v.time_since_epoch())};
-}
-
-/**
- * checks if a double fits into a specified integer type.
- * @tparam I
- * @param d
- * @return
- */
-template<std::integral I, typename J>
-bool fits_into(J d) {
-    if constexpr (std::is_floating_point_v<J>) {
-        if (std::isnan(d) || std::isinf(d)) {
-            return false;
-        }
-    }
-    if (d >= static_cast<J>(std::numeric_limits<I>::max())) {
-        return false;
-    }
-    if (d <= static_cast<J>(std::numeric_limits<I>::min())) {
-        return false;
-    }
-    return true;
-}
-
-/**
- * checks if a boost::multiprecision::number fits into a specified integer type.
- * @tparam I
- * @tparam B
- * @tparam e
- * @param n
- * @return
- */
-template<std::integral I, typename B, boost::multiprecision::expression_template_option e>
-constexpr bool fits_into(boost::multiprecision::number<B, e> const &n) {
-    return n <= std::numeric_limits<I>::max() && n >= std::numeric_limits<I>::min();
-}
-
 template<typename ResultType, typename ParsingType, char Separator, ConstexprString datatype>
 ResultType parse_date_time_fragment(std::string_view &s) {
     std::string_view res_s = s;
@@ -174,84 +86,109 @@ inline char *canonical_seconds_remove_empty_millis(char *it) {
     return it;
 }
 
-inline TimePoint add_duration_to_date_time(TimePoint const &tp, std::pair<std::chrono::months, std::chrono::nanoseconds> d) {
-    // only gets smaller, no overflow possible
-    auto [ymd, time] = rdf4cpp::util::deconstruct_timepoint(tp);
+template<typename T>
+inline nonstd::expected<T, datatypes::DynamicError> optional_to_overflow(std::optional<T> const &o) {
+    if (o.has_value()) {
+        return *o;
+    } else {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+}
 
-    boost::multiprecision::checked_int128_t checked_m = static_cast<unsigned int>(ymd.month());
-    checked_m += boost::multiprecision::checked_int128_t{static_cast<int64_t>(ymd.year())} * 12;
+/**
+ * returns nullopt on overflow
+ * @param tp
+ * @param d
+ * @return
+ */
+inline nonstd::expected<TimePoint, datatypes::DynamicError> add_duration_to_date_time(TimePoint const &tp, std::pair<std::chrono::months, std::chrono::nanoseconds> d) noexcept {
+    auto dec_tp = rdf4cpp::util::deconstruct_timepoint(tp);
+    if (!dec_tp.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    auto [ymd, time] = *dec_tp;
+
+    using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::util::Int128>;
+
+    Checked checked_m = static_cast<unsigned int>(ymd.month());
+    checked_m += Checked{static_cast<int64_t>(ymd.year())} * 12;
     checked_m += d.first.count();
 
     auto const checked_y = (checked_m -1 ) / 12;
 
     checked_m = abs(checked_m - 1);
 
-    auto const y = Year{static_cast<int64_t>(checked_y)};
-    auto const m = std::chrono::month{static_cast<unsigned>(static_cast<int64_t>(checked_m % 12 + 1))};
+    auto const y_casted = checked_y.checked_cast<int64_t>();
+    if (y_casted.is_invalid()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+
+    auto const y = Year{y_casted.get_value()};
+
+    auto const m_casted = (checked_m % 12 + 1).checked_cast<unsigned int>();
+    if (m_casted.is_invalid()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    auto const m = std::chrono::month{m_casted.get_value()};
 
     ymd = YearMonthDay{y, m, ymd.day()};
     if (!ymd.ok()) {
         ymd = YearMonthDay{ymd.year(), ymd.month(), std::chrono::last};
     }
 
-    TimePoint date = ymd.to_time_point_local();
+    auto date_opt = ymd.to_time_point_local();
+    if (!date_opt.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    rdf4cpp::util::TimePoint_Checked date = *date_opt;
     date += time;
     date += d.second;
 
-    rdf4cpp::util::deconstruct_timepoint(date); // check if it still fits into year, throws if not
+    auto date_uc = rdf4cpp::util::from_checked(date);
+    if (!date_uc.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
 
-    return date;
+    auto const deconstructed = rdf4cpp::util::deconstruct_timepoint(*date_uc);
+    if (!deconstructed.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+
+    return *date_uc;
+}
+
+inline rdf4cpp::util::ZonedTime_Checked apply_tz_checked(TimePoint tp, OptionalTimezone tz) {
+    return {tz.has_value() ? *tz : rdf4cpp::util::time_point_replacement_timezone, rdf4cpp::util::to_checked(tp)};
+}
+inline rdf4cpp::util::ZonedTime_Checked apply_tz_checked(std::pair<TimePoint, OptionalTimezone> const &tp) {
+    return apply_tz_checked(tp.first, tp.second);
 }
 
 inline nonstd::expected<std::chrono::nanoseconds, DynamicError> timepoint_sub(std::pair<TimePoint, OptionalTimezone> const &lhs, std::pair<TimePoint, OptionalTimezone> const &rhs) noexcept {
-    try {
-        ZonedTime const this_tp{lhs.second.has_value() ? *lhs.second : Timezone{},
-                                lhs.first};
+    rdf4cpp::util::ZonedTime_Checked const this_tp = apply_tz_checked(lhs);
+    rdf4cpp::util::ZonedTime_Checked const other_tp = apply_tz_checked(rhs);
 
-        ZonedTime const other_tp{rhs.second.has_value() ? *rhs.second : Timezone{},
-                                 rhs.first};
-
-        auto d = this_tp.get_sys_time() - other_tp.get_sys_time();
-        return std::chrono::duration_cast<std::chrono::nanoseconds>(d);
-    } catch (std::overflow_error const &) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
-    }
+    auto d = this_tp.get_sys_time() - other_tp.get_sys_time();
+    return util::optional_to_overflow(rdf4cpp::util::from_checked(std::chrono::duration_cast<std::chrono::duration<rdf4cpp::util::CheckedIntegral<int64_t>, std::chrono::nanoseconds::period>>(d)));
 }
 
 static inline std::partial_ordering compare_time_points(const rdf4cpp::TimePoint& a, std::optional<rdf4cpp::Timezone> atz,
                                                         const rdf4cpp::TimePoint& b, std::optional<rdf4cpp::Timezone> btz) noexcept {
-    auto apply_timezone = [](const rdf4cpp::TimePoint& t, rdf4cpp::Timezone tz) noexcept -> std::optional<rdf4cpp::TimePointSys> {
-        try {
-            return rdf4cpp::ZonedTime{tz, t}.get_sys_time();
-        } catch (const std::overflow_error&) {
-            return std::nullopt;
-        }
-    };
-
-    auto const cmp = [](const auto& a, const auto& b) noexcept -> std::partial_ordering {
-        if (a == b)
-            return std::partial_ordering::equivalent;
-        else if (a < b)
-            return std::partial_ordering::less;
-        else if (a > b)
-            return std::partial_ordering::greater;
+    auto const a_sys = apply_tz_checked(a, atz).get_sys_time();
+    auto const b_sys = apply_tz_checked(b, btz).get_sys_time();
+    if (a_sys.time_since_epoch().count().is_invalid() || b_sys.time_since_epoch().count().is_invalid()) {
         return std::partial_ordering::unordered;
-    };
-    auto const cmp_opt = [cmp](const std::optional<rdf4cpp::TimePointSys>& a, const std::optional<rdf4cpp::TimePointSys>& b) noexcept -> std::partial_ordering {
-        if (!a.has_value() || !b.has_value())
-            return std::partial_ordering::unordered;
-        return cmp(*a, *b);
-    };
-
-    if (!atz.has_value()) {
-        atz = rdf4cpp::util::time_point_replacement_timezone;
     }
-    if (!btz.has_value()) {
-        btz = rdf4cpp::util::time_point_replacement_timezone;
+    return a_sys <=> b_sys;
+}
+template<typename T>
+requires std::same_as<T, nonstd::expected<TimePoint, datatypes::DynamicError>> || std::same_as<T, std::optional<TimePoint>>
+inline static std::partial_ordering compare_time_points(T const &a, std::optional<rdf4cpp::Timezone> atz,
+                                                        T const &b, std::optional<rdf4cpp::Timezone> btz) noexcept {
+    if (!a.has_value() || !b.has_value()) {
+        return std::partial_ordering::unordered;
     }
-
-    auto a_sys = apply_timezone(a, *atz);
-    return cmp_opt(a_sys, apply_timezone(b, *btz));
+    return compare_time_points(*a, atz, *b, btz);
 }
 template<std::unsigned_integral T>
 constexpr T number_of_bits(T x) noexcept {
@@ -315,10 +252,14 @@ public:
     }
 };
 
-inline YearMonthDay normalize(YearMonthDay const &i) {
+inline nonstd::expected<YearMonthDay, datatypes::DynamicError> normalize(YearMonthDay const &i) {
     // normalize
     // see https://en.cppreference.com/w/cpp/chrono/year_month_day/operator_days
-    return YearMonthDay{(i + std::chrono::months{0}).to_time_point()};
+    auto t = (i + std::chrono::months{0}).to_time_point();
+    if (!t.has_value()) {
+        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    }
+    return util::optional_to_overflow(YearMonthDay::from_time_point_checked(*t));
 }
 
 template<std::integral I, I base = 10>

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -108,7 +108,7 @@ namespace rdf4cpp::datatypes::registry::util {
         }
         auto [ymd, time] = *dec_tp;
 
-        using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::util::Int128>;
+        using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::Int128>;
 
         Checked checked_m = static_cast<unsigned int>(ymd.month());
         checked_m += Checked{static_cast<int64_t>(ymd.year())} * 12;

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -95,19 +95,13 @@ namespace rdf4cpp::datatypes::registry::util {
         }
     }
 
-    /**
-     * returns nullopt on overflow
-     * @param tp
-     * @param d
-     * @return
-     */
     inline nonstd::expected<TimePoint, datatypes::DynamicError> add_duration_to_date_time(TimePoint const &tp, std::pair<std::chrono::months, std::chrono::nanoseconds> d) noexcept {
         auto dec_tp = rdf4cpp::util::deconstruct_timepoint(tp);
         if (!dec_tp.has_value()) {
             return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
         }
         auto [ymd, time] = *dec_tp;
-
+        // TODO use ymd.checked_add
         using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::Int128>;
 
         Checked checked_m = static_cast<unsigned int>(ymd.month());
@@ -136,11 +130,7 @@ namespace rdf4cpp::datatypes::registry::util {
             ymd = YearMonthDay{ymd.year(), ymd.month(), std::chrono::last};
         }
 
-        auto date_opt = ymd.to_time_point_local();
-        if (!date_opt.has_value()) {
-            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
-        }
-        rdf4cpp::util::TimePoint_Checked date = *date_opt;
+        rdf4cpp::util::TimePoint_Checked date = ymd.to_time_point_local();
         date += time;
         date += d.second;
 
@@ -255,11 +245,11 @@ namespace rdf4cpp::datatypes::registry::util {
     inline nonstd::expected<YearMonthDay, datatypes::DynamicError> normalize(YearMonthDay const &i) {
         // normalize
         // see https://en.cppreference.com/w/cpp/chrono/year_month_day/operator_days
-        auto t = (i + std::chrono::months{0}).to_time_point();
-        if (!t.has_value()) {
-            return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+        auto ym = i.add_checked(std::chrono::months{0});
+        if (!ym.has_value()) {
+            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
         }
-        return util::optional_to_overflow(YearMonthDay::from_time_point_checked(*t));
+        return util::optional_to_overflow(YearMonthDay::from_time_point_checked(ym->to_time_point()));
     }
 
     template<std::integral I, I base = 10>

--- a/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/DateTimeUtils.hpp
@@ -101,31 +101,12 @@ namespace rdf4cpp::datatypes::registry::util {
             return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
         }
         auto [ymd, time] = *dec_tp;
-        // TODO use ymd.checked_add
-        using Checked = rdf4cpp::util::CheckedIntegral<rdf4cpp::Int128>;
 
-        Checked checked_m = static_cast<unsigned int>(ymd.month());
-        checked_m += Checked{static_cast<int64_t>(ymd.year())} * 12;
-        checked_m += d.first.count();
-
-        auto const checked_y = (checked_m - 1) / 12;
-
-        checked_m = abs(checked_m - 1);
-
-        auto const y_casted = checked_y.checked_cast<int64_t>();
-        if (y_casted.is_invalid()) {
+        auto ymd_c = ymd.add_checked(d.first);
+        if (!ymd_c.has_value()) {
             return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
         }
-
-        auto const y = Year{y_casted.get_value()};
-
-        auto const m_casted = (checked_m % 12 + 1).checked_cast<unsigned int>();
-        if (m_casted.is_invalid()) {
-            return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
-        }
-        auto const m = std::chrono::month{m_casted.get_value()};
-
-        ymd = YearMonthDay{y, m, ymd.day()};
+        ymd = *ymd_c;
         if (!ymd.ok()) {
             ymd = YearMonthDay{ymd.year(), ymd.month(), std::chrono::last};
         }

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -69,7 +69,7 @@ nonstd::expected<capabilities::Numeric<xsd_decimal>::div_result_cpp_type, Dynami
         return nonstd::make_unexpected(DynamicError::DivideByZero);
     }
 
-    auto r = lhs.div_checked(rhs, 20);
+    auto r = lhs.div_checked(rhs, cpp_type::default_max_scale_increase);
     if (r.has_value())
         return r.value();
     else

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -148,8 +148,8 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_decim
 
     cpp_type::normalize(big_unscaled_value, exponent);
 
-    auto const unscaled_value = static_cast<int64_t>(big_unscaled_value);
-    if (big_unscaled_value != unscaled_value) {
+    int64_t unscaled_value;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(big_unscaled_value, unscaled_value)) {
         // unscaled value > 64 bit, cannot fit
         return std::nullopt;
     }

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -30,8 +30,7 @@ bool capabilities::Default<xsd_decimal>::serialize_simplified_string(cpp_type co
     cpp_type v = value;
     v.normalize();
     if (v.get_exponent() == 0) {
-        auto const s = static_cast<boost::multiprecision::checked_int128_t>(v).str();
-        return writer::write_str(s, writer);
+        return rdf4cpp::util::to_chars_canonical(v.get_unscaled_value(), writer);
     } else {
         auto const s = static_cast<std::string>(v);
         return writer::write_str(s, writer);
@@ -70,7 +69,7 @@ nonstd::expected<capabilities::Numeric<xsd_decimal>::div_result_cpp_type, Dynami
         return nonstd::make_unexpected(DynamicError::DivideByZero);
     }
 
-    auto r = lhs.div_checked(rhs, 1000);
+    auto r = lhs.div_checked(rhs, 20);
     if (r.has_value())
         return r.value();
     else

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -30,7 +30,7 @@ bool capabilities::Default<xsd_decimal>::serialize_simplified_string(cpp_type co
     cpp_type v = value;
     v.normalize();
     if (v.get_exponent() == 0) {
-        auto const s = static_cast<boost::multiprecision::cpp_int>(v).str();
+        auto const s = static_cast<boost::multiprecision::checked_int128_t>(v).str();
         return writer::write_str(s, writer);
     } else {
         auto const s = static_cast<std::string>(v);

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -108,17 +108,17 @@ nonstd::expected<capabilities::Numeric<xsd_decimal>::abs_result_cpp_type, Dynami
 
 template<>
 nonstd::expected<capabilities::Numeric<xsd_decimal>::round_result_cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::round(cpp_type const &operand) noexcept {
-    return operand.round(rdf4cpp::RoundingMode::Round);
+    return operand.round(rdf4cpp::util::RoundingMode::Round);
 }
 
 template<>
 nonstd::expected<capabilities::Numeric<xsd_decimal>::floor_result_cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::floor(cpp_type const &operand) noexcept {
-    return operand.round(rdf4cpp::RoundingMode::Floor);
+    return operand.round(rdf4cpp::util::RoundingMode::Floor);
 }
 
 template<>
 nonstd::expected<capabilities::Numeric<xsd_decimal>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::ceil(cpp_type const &operand) noexcept {
-    return operand.round(rdf4cpp::RoundingMode::Ceil);
+    return operand.round(rdf4cpp::util::RoundingMode::Ceil);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/Decimal.hpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.hpp
@@ -18,7 +18,7 @@ template<>
 struct DatatypeMapping<xsd_decimal> {
     // needs at least 18 decimal digits of precision
     // see: https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#dt-decimal
-    using cpp_datatype = rdf4cpp::BigDecimal<>;
+    using cpp_datatype = rdf4cpp::Decimal128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.cpp
@@ -3,25 +3,25 @@
 #include <stdexcept>
 
 #include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 capabilities::Default<xsd_non_negative_integer>::cpp_type capabilities::Default<xsd_non_negative_integer>::from_string(std::string_view s) {
-    cpp_type ret;
-
-    try {
-        ret = cpp_type{s};
-    } catch (std::runtime_error const &e) {
-        throw InvalidNode{std::format("{} parsing error: {}", identifier, e.what())};
-    }
+    cpp_type ret = util::from_chars<cpp_type, identifier>(s);
 
     if (ret < 0) {
         throw InvalidNode{std::format("{} parsing error: found negative value", identifier)};
     }
 
     return ret;
+}
+
+template<>
+bool capabilities::Default<xsd_non_negative_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept {
+    return rdf4cpp::util::to_chars_canonical(value, writer);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
@@ -5,14 +5,14 @@
 #include <rdf4cpp/datatypes/registry/LiteralDatatypeImpl.hpp>
 #include <rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_negative_integer> {
-    using cpp_datatype = boost::multiprecision::cpp_int;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>
@@ -27,6 +27,9 @@ struct DatatypeNumericStubMapping<xsd_non_negative_integer> {
 
 template<>
 capabilities::Default<xsd_non_negative_integer>::cpp_type capabilities::Default<xsd_non_negative_integer>::from_string(std::string_view s);
+
+template<>
+bool capabilities::Default<xsd_non_negative_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_non_negative_integer>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
@@ -12,7 +12,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_negative_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
@@ -12,7 +12,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_negative_integer> {
-    using cpp_datatype = rdf4cpp::util::BigInt;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp
@@ -12,7 +12,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_negative_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::util::BigInt;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.cpp
@@ -1,25 +1,25 @@
 #include "PositiveInteger.hpp"
 
 #include <stdexcept>
+#include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 capabilities::Default<xsd_positive_integer>::cpp_type capabilities::Default<xsd_positive_integer>::from_string(std::string_view s) {
-    cpp_type ret;
-
-    try {
-        ret = cpp_type{s};
-    } catch (std::runtime_error const &e) {
-        throw InvalidNode{std::format("{} parsing error: {}", identifier, e.what())};
-    }
+    cpp_type ret = util::from_chars<cpp_type, identifier>(s);
 
     if (ret < 1) {
         throw InvalidNode{std::format("{} parsing error: found non-positive value", identifier)};
     }
 
     return ret;
+}
+
+template<>
+bool capabilities::Default<xsd_positive_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept {
+    return rdf4cpp::util::to_chars_canonical(value, writer);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_positive_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::util::BigInt;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_positive_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
@@ -6,14 +6,14 @@
 #include <rdf4cpp/datatypes/xsd/integers/non_negative/NonNegativeInteger.hpp>
 #include <rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_positive_integer> {
-    using cpp_datatype = boost::multiprecision::cpp_int;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>
@@ -28,6 +28,9 @@ struct DatatypeNumericStubMapping<xsd_positive_integer> {
 
 template<>
 capabilities::Default<xsd_positive_integer>::cpp_type capabilities::Default<xsd_positive_integer>::from_string(std::string_view s);
+
+template<>
+bool capabilities::Default<xsd_positive_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_positive_integer>::effective_boolean_value(cpp_type const &) noexcept;

--- a/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_negative/PositiveInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_positive_integer> {
-    using cpp_datatype = rdf4cpp::util::BigInt;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.cpp
@@ -3,25 +3,25 @@
 #include <stdexcept>
 
 #include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 capabilities::Default<xsd_negative_integer>::cpp_type capabilities::Default<xsd_negative_integer>::from_string(std::string_view s) {
-    cpp_type ret;
-
-    try {
-        ret = cpp_type{s};
-    } catch (std::runtime_error const &e) {
-        throw InvalidNode{std::format("{} parsing error: {}", identifier, e.what())};
-    }
+    cpp_type ret = util::from_chars<cpp_type, identifier>(s);
 
     if (ret > -1) {
         throw InvalidNode{std::format("{} parsing error: found non-negative value", identifier)};
     }
 
     return ret;
+}
+
+template<>
+bool capabilities::Default<xsd_negative_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept {
+    return rdf4cpp::util::to_chars_canonical(value, writer);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_negative_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_negative_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::util::BigInt;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
@@ -6,14 +6,14 @@
 #include <rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp>
 #include <rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_negative_integer> {
-    using cpp_datatype = boost::multiprecision::cpp_int;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>
@@ -31,6 +31,9 @@ struct DatatypeNumericStubMapping<xsd_negative_integer> {
  */
 template<>
 capabilities::Default<xsd_negative_integer>::cpp_type capabilities::Default<xsd_negative_integer>::from_string(std::string_view s);
+
+template<>
+bool capabilities::Default<xsd_negative_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_negative_integer>::effective_boolean_value(cpp_type const &) noexcept;

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NegativeInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_negative_integer> {
-    using cpp_datatype = rdf4cpp::util::BigInt;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.cpp
@@ -3,25 +3,25 @@
 #include <stdexcept>
 
 #include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 capabilities::Default<xsd_non_positive_integer>::cpp_type capabilities::Default<xsd_non_positive_integer>::from_string(std::string_view s) {
-    cpp_type ret;
-
-    try {
-        ret = cpp_type{s};
-    } catch (std::runtime_error const &e) {
-        throw InvalidNode{std::format("{} parsing error: {}",identifier, e.what())};
-    }
+    cpp_type ret = util::from_chars<cpp_type, identifier>(s);
 
     if (ret > 0) {
         throw InvalidNode{std::format("{} parsing error: found non-negative value", identifier)};
     }
 
     return ret;
+}
+
+template<>
+bool capabilities::Default<xsd_non_positive_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept {
+    return rdf4cpp::util::to_chars_canonical(value, writer);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_positive_integer> {
-    using cpp_datatype = rdf4cpp::util::BigInt;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
@@ -6,14 +6,14 @@
 #include <rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp>
 #include <rdf4cpp/datatypes/registry/FixedIdMappings.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_positive_integer> {
-    using cpp_datatype = boost::multiprecision::cpp_int;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>
@@ -28,6 +28,9 @@ struct DatatypeNumericStubMapping<xsd_non_positive_integer> {
 
 template<>
 capabilities::Default<xsd_non_positive_integer>::cpp_type capabilities::Default<xsd_non_positive_integer>::from_string(std::string_view s);
+
+template<>
+bool capabilities::Default<xsd_non_positive_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept;
 
 template<>
 bool capabilities::Logical<xsd_non_positive_integer>::effective_boolean_value(cpp_type const &value) noexcept;

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_positive_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::util::BigInt;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/non_positive/NonPositiveInteger.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_non_positive_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
@@ -3,30 +3,44 @@
 #include <stdexcept>
 
 #include <rdf4cpp/InvalidNode.hpp>
+#include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 capabilities::Default<xsd_integer>::cpp_type capabilities::Default<xsd_integer>::from_string(std::string_view s) {
-    if (s.starts_with('+')) {
-        s.remove_prefix(1);
-    }
+    return util::from_chars<cpp_type, identifier>(s);
+}
 
-    if (auto const pos = s.find_first_not_of('0'); pos != std::string::npos) {
-        s.remove_prefix(pos);
-    }
-
-    try {
-        return cpp_type{s};
-    } catch (std::runtime_error const &e) {
-        throw InvalidNode{std::format("{} parsing error: {}", identifier, e.what())};
-    }
+template<>
+bool capabilities::Default<xsd_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept {
+    return rdf4cpp::util::to_chars_canonical(value, writer);
 }
 
 template<>
 bool capabilities::Logical<xsd_integer>::effective_boolean_value(cpp_type const &value) noexcept {
     return value != 0;
+}
+
+template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::add_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::add(cpp_type const &lhs, cpp_type const &rhs) noexcept {
+    // https://www.w3.org/TR/xpath-functions/#op.numeric
+    // needs overflow protection
+    cpp_type r;
+    if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r))
+        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    return r;
+}
+
+template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::sub_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::sub(cpp_type const &lhs, cpp_type const &rhs) noexcept {
+    // https://www.w3.org/TR/xpath-functions/#op.numeric
+    // needs overflow protection
+    cpp_type r;
+    if (rdf4cpp::util::detail::sub_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r))
+        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    return r;
 }
 
 template<>
@@ -41,8 +55,30 @@ nonstd::expected<capabilities::Numeric<xsd_integer>::div_result_cpp_type, Dynami
 }
 
 template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::mul_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::mul(cpp_type const &lhs, cpp_type const &rhs) noexcept {
+    // https://www.w3.org/TR/xpath-functions/#op.numeric
+    // decimal needs overflow protection
+    cpp_type r;
+    if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r))
+        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    return r;
+}
+
+template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::abs_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::neg(cpp_type const &operand) noexcept {
+    cpp_type r;
+    if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(operand, cpp_type{-1}, r))
+        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    return r;
+}
+
+template<>
 nonstd::expected<capabilities::Numeric<xsd_integer>::abs_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::abs(cpp_type const &operand) noexcept {
-    return boost::multiprecision::abs(operand);
+    if (operand >= 0) {
+        return operand;
+    } else {
+        return neg(operand);
+    }
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
@@ -28,8 +28,9 @@ nonstd::expected<capabilities::Numeric<xsd_integer>::add_result_cpp_type, Dynami
     // https://www.w3.org/TR/xpath-functions/#op.numeric
     // needs overflow protection
     cpp_type r;
-    if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r))
+    if (rdf4cpp::util::detail::add_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    }
     return r;
 }
 
@@ -38,8 +39,9 @@ nonstd::expected<capabilities::Numeric<xsd_integer>::sub_result_cpp_type, Dynami
     // https://www.w3.org/TR/xpath-functions/#op.numeric
     // needs overflow protection
     cpp_type r;
-    if (rdf4cpp::util::detail::sub_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r))
+    if (rdf4cpp::util::detail::sub_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    }
     return r;
 }
 
@@ -59,16 +61,18 @@ nonstd::expected<capabilities::Numeric<xsd_integer>::mul_result_cpp_type, Dynami
     // https://www.w3.org/TR/xpath-functions/#op.numeric
     // decimal needs overflow protection
     cpp_type r;
-    if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r))
+    if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(lhs, rhs, r)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    }
     return r;
 }
 
 template<>
 nonstd::expected<capabilities::Numeric<xsd_integer>::abs_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::neg(cpp_type const &operand) noexcept {
     cpp_type r;
-    if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(operand, cpp_type{-1}, r))
+    if (rdf4cpp::util::detail::mul_checked<rdf4cpp::util::detail::OverflowMode::Checked>(operand, cpp_type{-1}, r)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    }
     return r;
 }
 

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_integer> {
-    using cpp_datatype = boost::multiprecision::cpp_int;
+    using cpp_datatype = boost::multiprecision::checked_int128_t;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_integer> {
-    using cpp_datatype = rdf4cpp::util::BigInt;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
@@ -13,7 +13,7 @@ namespace rdf4cpp::datatypes::registry {
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_integer> {
-    using cpp_datatype = rdf4cpp::util::Int128;
+    using cpp_datatype = rdf4cpp::util::BigInt;
 };
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
@@ -6,14 +6,14 @@
 #include <rdf4cpp/datatypes/registry/LiteralDatatypeImpl.hpp>
 #include <rdf4cpp/datatypes/xsd/Decimal.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/util/Int128.hpp>
 
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
 template<>
 struct DatatypeMapping<xsd_integer> {
-    using cpp_datatype = boost::multiprecision::checked_int128_t;
+    using cpp_datatype = rdf4cpp::util::Int128;
 };
 
 template<>
@@ -30,10 +30,25 @@ template<>
 capabilities::Default<xsd_integer>::cpp_type capabilities::Default<xsd_integer>::from_string(std::string_view s);
 
 template<>
+bool capabilities::Default<xsd_integer>::serialize_canonical_string(cpp_type const &value, writer::BufWriterParts writer) noexcept;
+
+template<>
 bool capabilities::Logical<xsd_integer>::effective_boolean_value(cpp_type const &value) noexcept;
 
 template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::add_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::add(cpp_type const &lhs, cpp_type const &rhs) noexcept;
+
+template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::sub_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::sub(cpp_type const &lhs, cpp_type const &rhs) noexcept;
+
+template<>
 nonstd::expected<capabilities::Numeric<xsd_integer>::div_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::div(cpp_type const &lhs, cpp_type const &rhs) noexcept;
+
+template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::mul_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::mul(cpp_type const &lhs, cpp_type const &rhs) noexcept;
+
+template<>
+nonstd::expected<capabilities::Numeric<xsd_integer>::abs_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::neg(cpp_type const &operand) noexcept;
 
 template<>
 nonstd::expected<capabilities::Numeric<xsd_integer>::abs_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::abs(cpp_type const &operand) noexcept;

--- a/src/rdf4cpp/datatypes/xsd/time/Date.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Date.cpp
@@ -54,7 +54,7 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_date>
     if (value.second.has_value()) {
         return std::nullopt;
     }
-    auto i = value.first.to_time_point()->time_since_epoch().count();
+    auto i = value.first.to_time_point().time_since_epoch().count();
     int64_t i64;
     if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(i, i64)) [[unlikely]] {
         return std::nullopt;
@@ -69,7 +69,7 @@ capabilities::Inlineable<xsd_date>::cpp_type capabilities::Inlineable<xsd_date>:
 }
 
 rdf4cpp::TimePoint date_to_tp(YearMonthDay const &d) noexcept {
-    return *rdf4cpp::util::construct_timepoint(d, rdf4cpp::util::time_point_replacement_time_of_day);
+    return rdf4cpp::util::construct_timepoint(d, rdf4cpp::util::time_point_replacement_time_of_day);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/time/Date.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Date.cpp
@@ -14,7 +14,11 @@ capabilities::Default<xsd_date>::cpp_type capabilities::Default<xsd_date>::from_
     auto day = parse_date_time_fragment<std::chrono::day, unsigned int, '\0', identifier>(s);
     auto date = YearMonthDay{year, month, day};
     if (registry::relaxed_parsing_mode && !date.ok()) {
-        date = normalize(date);
+        auto const norm = normalize(date);
+        if (!norm.has_value()) {
+            throw InvalidNode(std::format("{} parsing error: failed to normalize", identifier, date));
+        }
+        date = *norm;
     }
     if (!date.ok()) {
         throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
@@ -50,11 +54,12 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_date>
     if (value.second.has_value()) {
         return std::nullopt;
     }
-    auto i = value.first.to_time_point().time_since_epoch().count();
-    if (!util::fits_into<int64_t>(i)) [[unlikely]] {
+    auto i = value.first.to_time_point()->time_since_epoch().count();
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(i, i64)) [[unlikely]] {
         return std::nullopt;
     }
-    return util::try_pack_integral<storage::identifier::LiteralID>(static_cast<int64_t>(i));
+    return util::try_pack_integral<storage::identifier::LiteralID>(i64);
 }
 
 template<>
@@ -64,7 +69,7 @@ capabilities::Inlineable<xsd_date>::cpp_type capabilities::Inlineable<xsd_date>:
 }
 
 rdf4cpp::TimePoint date_to_tp(YearMonthDay const &d) noexcept {
-    return rdf4cpp::util::construct_timepoint(d, rdf4cpp::util::time_point_replacement_time_of_day);
+    return *rdf4cpp::util::construct_timepoint(d, rdf4cpp::util::time_point_replacement_time_of_day);
 }
 
 template<>
@@ -97,8 +102,15 @@ nonstd::expected<capabilities::Timepoint<xsd_date>::cpp_type, DynamicError>
 capabilities::Timepoint<xsd_date>::timepoint_duration_add(cpp_type const &tp, timepoint_duration_operand_cpp_type const &dur) noexcept {
     auto const super_tp = Promotable<xsd_date>::promote(tp);
     auto res_tp = util::add_duration_to_date_time(super_tp.first, dur);
+    if (!res_tp.has_value()) {
+        return nonstd::make_unexpected(res_tp.error());
+    }
 
-    auto [date, _] = rdf4cpp::util::deconstruct_timepoint(res_tp);
+    auto deconstructed = rdf4cpp::util::deconstruct_timepoint(*res_tp);
+    if (!deconstructed.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    auto [date, _] = *deconstructed;
     return std::make_pair(date, super_tp.second);
 }
 
@@ -106,9 +118,26 @@ template<>
 nonstd::expected<capabilities::Timepoint<xsd_date>::cpp_type, DynamicError>
 capabilities::Timepoint<xsd_date>::timepoint_duration_sub(cpp_type const &tp, timepoint_duration_operand_cpp_type const &dur) noexcept {
     auto const super_tp = Promotable<xsd_date>::promote(tp);
-    auto res_tp = util::add_duration_to_date_time(super_tp.first, std::make_pair(-dur.first, -dur.second));
 
-    auto [date, _] = rdf4cpp::util::deconstruct_timepoint(res_tp);
+    auto const sdur_month = rdf4cpp::util::from_checked(-rdf4cpp::util::to_checked(dur.first));
+    auto const sdur_nanos = rdf4cpp::util::from_checked(-rdf4cpp::util::to_checked((dur.second)));
+    if (!sdur_month.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    if (!sdur_nanos.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+
+    auto res_tp = util::add_duration_to_date_time(super_tp.first, std::make_pair(*sdur_month, *sdur_nanos));
+    if (!res_tp.has_value()) {
+        return nonstd::make_unexpected(res_tp.error());
+    }
+
+    auto deconstructed = rdf4cpp::util::deconstruct_timepoint(*res_tp);
+    if (!deconstructed.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    auto [date, _] = *deconstructed;
     return std::make_pair(date, super_tp.second);
 }
 

--- a/src/rdf4cpp/datatypes/xsd/time/DateTime.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DateTime.cpp
@@ -65,7 +65,11 @@ bool capabilities::Default<xsd_dateTime>::serialize_canonical_string(cpp_type co
                              registry::util::chrono_max_canonical_string_chars::minutes + 1 +
                              registry::util::chrono_max_canonical_string_chars::seconds + Timezone::max_canonical_string_chars>
             buff;
-    auto [date, time] = *rdf4cpp::util::deconstruct_timepoint(value.first);
+    auto dec = rdf4cpp::util::deconstruct_timepoint(value.first);
+    if (!dec.has_value()) [[unlikely]] {
+        return writer::write_str("invalid DateTime", writer);
+    }
+    auto [date, time] = *dec;
     char *it = std::format_to(buff.data(), "{}T{:%H:%M:%S}", date, std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)});
     it = util::canonical_seconds_remove_empty_millis(it);
     if (value.second.has_value()) {

--- a/src/rdf4cpp/datatypes/xsd/time/DateTime.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DateTime.cpp
@@ -41,10 +41,7 @@ capabilities::Default<xsd_dateTime>::cpp_type capabilities::Default<xsd_dateTime
     if (!registry::relaxed_parsing_mode) {
         if (time == std::chrono::hours{24}) {
             auto const tp = date.to_time_point_local();
-            if (!tp.has_value()) {
-                throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
-            }
-            date = YearMonthDay{*tp + std::chrono::days{1}};
+            date = YearMonthDay{tp + std::chrono::days{1}};
             if (!date.ok()) {
                 throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
             }
@@ -55,10 +52,7 @@ capabilities::Default<xsd_dateTime>::cpp_type capabilities::Default<xsd_dateTime
     }
 
     auto const tp = rdf4cpp::util::construct_timepoint(date, time);
-    if (!tp.has_value()) {
-        throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
-    }
-    return std::make_pair(*tp, tz);
+    return std::make_pair(tp, tz);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/time/DateTime.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DateTime.cpp
@@ -17,7 +17,11 @@ capabilities::Default<xsd_dateTime>::cpp_type capabilities::Default<xsd_dateTime
     std::chrono::nanoseconds ms = parse_nanoseconds<identifier>(s);
     auto date = YearMonthDay{year, month, day};
     if (registry::relaxed_parsing_mode && !date.ok()) {
-        date = normalize(date);
+        auto const norm = normalize(date);
+        if (!norm.has_value()) {
+            throw InvalidNode(std::format("{} parsing error: failed to normalize", identifier, date));
+        }
+        date = *norm;
     }
     if (!date.ok()) {
         throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
@@ -36,7 +40,11 @@ capabilities::Default<xsd_dateTime>::cpp_type capabilities::Default<xsd_dateTime
     auto time = hours + minutes + ms;
     if (!registry::relaxed_parsing_mode) {
         if (time == std::chrono::hours{24}) {
-            date = YearMonthDay{date.to_time_point_local() + std::chrono::days{1}};
+            auto const tp = date.to_time_point_local();
+            if (!tp.has_value()) {
+                throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
+            }
+            date = YearMonthDay{*tp + std::chrono::days{1}};
             if (!date.ok()) {
                 throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
             }
@@ -46,7 +54,11 @@ capabilities::Default<xsd_dateTime>::cpp_type capabilities::Default<xsd_dateTime
         }
     }
 
-    return std::make_pair(rdf4cpp::util::construct_timepoint(date, time), tz);
+    auto const tp = rdf4cpp::util::construct_timepoint(date, time);
+    if (!tp.has_value()) {
+        throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
+    }
+    return std::make_pair(*tp, tz);
 }
 
 template<>
@@ -59,7 +71,7 @@ bool capabilities::Default<xsd_dateTime>::serialize_canonical_string(cpp_type co
                              registry::util::chrono_max_canonical_string_chars::minutes + 1 +
                              registry::util::chrono_max_canonical_string_chars::seconds + Timezone::max_canonical_string_chars>
             buff;
-    auto [date, time] = rdf4cpp::util::deconstruct_timepoint(value.first);
+    auto [date, time] = *rdf4cpp::util::deconstruct_timepoint(value.first);
     char *it = std::format_to(buff.data(), "{}T{:%H:%M:%S}", date, std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)});
     it = util::canonical_seconds_remove_empty_millis(it);
     if (value.second.has_value()) {
@@ -74,14 +86,14 @@ template<>
 std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_dateTime>::try_into_inlined(cpp_type const &value) noexcept {
     if (value.second.has_value())
         return std::nullopt;
-    auto tp_sec = std::chrono::floor<std::chrono::duration<boost::multiprecision::checked_int128_t, std::chrono::seconds::period>>(value.first);
+    auto tp_sec = std::chrono::floor<std::chrono::duration<cpp_type::first_type::duration::rep, std::chrono::seconds::period>>(value.first);
     if ((value.first - tp_sec).count() != 0)
         return std::nullopt;
-    if (!util::fits_into<int64_t>(tp_sec.time_since_epoch().count())) {
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(tp_sec.time_since_epoch().count(), i64)) {
         return std::nullopt;
     }
-    auto s = static_cast<int64_t>(tp_sec.time_since_epoch().count());
-    return util::try_pack_integral<storage::identifier::LiteralID>(s);
+    return util::try_pack_integral<storage::identifier::LiteralID>(i64);
 }
 
 template<>
@@ -103,23 +115,21 @@ capabilities::Timepoint<xsd_dateTime>::timepoint_sub(cpp_type const &lhs, cpp_ty
 template<>
 nonstd::expected<capabilities::Timepoint<xsd_dateTime>::cpp_type, DynamicError>
 capabilities::Timepoint<xsd_dateTime>::timepoint_duration_add(cpp_type const &tp, timepoint_duration_operand_cpp_type const &dur) noexcept {
-    try {
-        auto ret_tp = util::add_duration_to_date_time(tp.first, dur);
-        return std::make_pair(ret_tp, tp.second);
-    } catch (std::overflow_error const &) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    auto ret_tp = util::add_duration_to_date_time(tp.first, dur);
+    if (!ret_tp.has_value()) {
+        return nonstd::make_unexpected(ret_tp.error());
     }
+    return std::make_pair(*ret_tp, tp.second);
 }
 
 template<>
 nonstd::expected<capabilities::Timepoint<xsd_dateTime>::cpp_type, DynamicError>
 capabilities::Timepoint<xsd_dateTime>::timepoint_duration_sub(cpp_type const &tp, timepoint_duration_operand_cpp_type const &dur) noexcept {
-    try {
-        auto ret_tp = util::add_duration_to_date_time(tp.first, std::make_pair(-dur.first, -dur.second));
-        return std::make_pair(ret_tp, tp.second);
-    } catch (std::overflow_error const &) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    auto ret_tp = util::add_duration_to_date_time(tp.first, std::make_pair(-dur.first, -dur.second));
+    if (!ret_tp.has_value()) {
+        return nonstd::make_unexpected(ret_tp.error());
     }
+    return std::make_pair(*ret_tp, tp.second);
 }
 
 #endif

--- a/src/rdf4cpp/datatypes/xsd/time/DateTimeStamp.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DateTimeStamp.cpp
@@ -24,7 +24,11 @@ capabilities::Default<xsd_dateTimeStamp>::cpp_type capabilities::Default<xsd_dat
     std::chrono::nanoseconds ms = parse_nanoseconds<identifier>(s.substr(0, p));
     auto date = YearMonthDay{year, month, day};
     if (registry::relaxed_parsing_mode && !date.ok()) {
-        date = normalize(date);
+        auto const norm = normalize(date);
+        if (!norm.has_value()) {
+            throw InvalidNode(std::format("{} parsing error: failed to normalize", identifier, date));
+        }
+        date = *norm;
     }
     if (!date.ok()) {
         throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
@@ -43,7 +47,11 @@ capabilities::Default<xsd_dateTimeStamp>::cpp_type capabilities::Default<xsd_dat
     auto time = hours + minutes + ms;
     if (!registry::relaxed_parsing_mode) {
         if (time == std::chrono::hours{24}) {
-            date = YearMonthDay{date.to_time_point_local() + std::chrono::days{1}};
+            auto const tp = date.to_time_point_local();
+            if (!tp.has_value()) {
+                throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
+            }
+            date = YearMonthDay{*tp + std::chrono::days{1}};
             if (!date.ok()) {
                 throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
             }
@@ -52,8 +60,11 @@ capabilities::Default<xsd_dateTimeStamp>::cpp_type capabilities::Default<xsd_dat
             throw InvalidNode(std::format("{} parsing error: invalid time of day", identifier));
         }
     }
-
-    return rdf4cpp::ZonedTime{tz, rdf4cpp::util::construct_timepoint(date, time)};
+    auto const tp = rdf4cpp::util::construct_timepoint(date, time);
+    if (!tp.has_value()) {
+        throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
+    }
+    return rdf4cpp::ZonedTime{tz, *tp};
 }
 
 template<>
@@ -66,7 +77,7 @@ bool capabilities::Default<xsd_dateTimeStamp>::serialize_canonical_string(cpp_ty
                              registry::util::chrono_max_canonical_string_chars::minutes + 1 +
                              registry::util::chrono_max_canonical_string_chars::seconds + Timezone::max_canonical_string_chars>
             buff;
-    auto [date, time] = rdf4cpp::util::deconstruct_timepoint(value.get_local_time());
+    auto [date, time] = *rdf4cpp::util::deconstruct_timepoint(value.get_local_time());
     char *it = std::format_to(buff.data(), "{}T{:%H:%M:%S}", date, std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)});
     it = util::canonical_seconds_remove_empty_millis(it);
     it = value.get_time_zone().to_canonical_string(it);
@@ -82,10 +93,11 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_dateT
     auto tp_sec = std::chrono::floor<std::chrono::seconds>(value.get_sys_time());
     if ((value.get_sys_time() - tp_sec).count() != 0)
         return std::nullopt;
-    if (!util::fits_into<int64_t>(tp_sec.time_since_epoch().count()))
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(tp_sec.time_since_epoch().count(), i64)) {
         return std::nullopt;
-    auto s = static_cast<int64_t>(tp_sec.time_since_epoch().count());
-    return util::try_pack_integral<storage::identifier::LiteralID>(s);
+    }
+    return util::try_pack_integral<storage::identifier::LiteralID>(i64);
 }
 
 template<>
@@ -133,23 +145,21 @@ capabilities::Timepoint<xsd_dateTimeStamp>::timepoint_sub(cpp_type const &lhs, c
 template<>
 nonstd::expected<capabilities::Timepoint<xsd_dateTimeStamp>::cpp_type, DynamicError>
 capabilities::Timepoint<xsd_dateTimeStamp>::timepoint_duration_add(cpp_type const &tp, timepoint_duration_operand_cpp_type const &dur) noexcept {
-    try {
-        auto ret_tp = util::add_duration_to_date_time(tp.get_local_time(), dur);
-        return ZonedTime{tp.get_time_zone(), ret_tp};
-    } catch (std::overflow_error const &) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    auto ret_tp = util::add_duration_to_date_time(tp.get_local_time(), dur);
+    if (!ret_tp.has_value()) {
+        return nonstd::make_unexpected(ret_tp.error());
     }
+    return ZonedTime{tp.get_time_zone(), *ret_tp};
 }
 
 template<>
 nonstd::expected<capabilities::Timepoint<xsd_dateTimeStamp>::cpp_type, DynamicError>
 capabilities::Timepoint<xsd_dateTimeStamp>::timepoint_duration_sub(cpp_type const &tp, timepoint_duration_operand_cpp_type const &dur) noexcept {
-    try {
-        auto ret_tp = util::add_duration_to_date_time(tp.get_local_time(), std::make_pair(-dur.first, -dur.second));
-        return ZonedTime{tp.get_time_zone(), ret_tp};
-    } catch (std::overflow_error const &) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
+    auto ret_tp = util::add_duration_to_date_time(tp.get_local_time(), std::make_pair(-dur.first, -dur.second));
+    if (!ret_tp.has_value()) {
+        return nonstd::make_unexpected(ret_tp.error());
     }
+    return ZonedTime{tp.get_time_zone(), *ret_tp};
 }
 
 #endif

--- a/src/rdf4cpp/datatypes/xsd/time/DateTimeStamp.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DateTimeStamp.cpp
@@ -48,10 +48,7 @@ capabilities::Default<xsd_dateTimeStamp>::cpp_type capabilities::Default<xsd_dat
     if (!registry::relaxed_parsing_mode) {
         if (time == std::chrono::hours{24}) {
             auto const tp = date.to_time_point_local();
-            if (!tp.has_value()) {
-                throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
-            }
-            date = YearMonthDay{*tp + std::chrono::days{1}};
+            date = YearMonthDay{tp + std::chrono::days{1}};
             if (!date.ok()) {
                 throw InvalidNode(std::format("{} parsing error: {} is invalid", identifier, date));
             }
@@ -61,10 +58,7 @@ capabilities::Default<xsd_dateTimeStamp>::cpp_type capabilities::Default<xsd_dat
         }
     }
     auto const tp = rdf4cpp::util::construct_timepoint(date, time);
-    if (!tp.has_value()) {
-        throw InvalidNode(std::format("{} parsing error: timepoint is out of range", identifier, date));
-    }
-    return rdf4cpp::ZonedTime{tz, *tp};
+    return rdf4cpp::ZonedTime{tz, tp};
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/time/DateTimeStamp.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DateTimeStamp.cpp
@@ -71,7 +71,11 @@ bool capabilities::Default<xsd_dateTimeStamp>::serialize_canonical_string(cpp_ty
                              registry::util::chrono_max_canonical_string_chars::minutes + 1 +
                              registry::util::chrono_max_canonical_string_chars::seconds + Timezone::max_canonical_string_chars>
             buff;
-    auto [date, time] = *rdf4cpp::util::deconstruct_timepoint(value.get_local_time());
+    auto dec = rdf4cpp::util::deconstruct_timepoint(value.get_local_time());
+    if (!dec.has_value()) [[unlikely]] {
+        return writer::write_str("invalid DateTimeStamp", writer);
+    }
+    auto [date, time] = *dec;
     char *it = std::format_to(buff.data(), "{}T{:%H:%M:%S}", date, std::chrono::hh_mm_ss{std::chrono::duration_cast<std::chrono::nanoseconds>(time)});
     it = util::canonical_seconds_remove_empty_millis(it);
     it = value.get_time_zone().to_canonical_string(it);

--- a/src/rdf4cpp/datatypes/xsd/time/Day.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Day.cpp
@@ -38,7 +38,7 @@ bool capabilities::Default<xsd_gDay>::serialize_canonical_string(cpp_type const 
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gDay>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto day_to_tp = [](std::chrono::day d) noexcept -> rdf4cpp::TimePoint {
+    auto day_to_tp = [](std::chrono::day d) noexcept -> std::optional<TimePoint> {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), rdf4cpp::util::time_point_replacement_date.month(), d}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(day_to_tp(lhs.first), lhs.second, day_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/Day.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Day.cpp
@@ -38,7 +38,7 @@ bool capabilities::Default<xsd_gDay>::serialize_canonical_string(cpp_type const 
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gDay>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto day_to_tp = [](std::chrono::day d) noexcept -> std::optional<TimePoint> {
+    auto day_to_tp = [](std::chrono::day d) noexcept -> TimePoint {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), rdf4cpp::util::time_point_replacement_date.month(), d}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(day_to_tp(lhs.first), lhs.second, day_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/DayTimeDuration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DayTimeDuration.cpp
@@ -170,7 +170,7 @@ capabilities::Duration<xsd_dayTimeDuration>::duration_sub(cpp_type const &lhs, c
 template<>
 nonstd::expected<capabilities::Duration<xsd_dayTimeDuration>::duration_div_result_cpp_type, DynamicError>
 capabilities::Duration<xsd_dayTimeDuration>::duration_div(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto r = BigDecimal<>{lhs.count(), 0}.div_checked(BigDecimal<>{rhs.count(), 0}, 1000);
+    auto r = Decimal128{lhs.count(), 0}.div_checked(Decimal128{rhs.count(), 0}, 1000);
     if (!r.has_value()) {
         return nonstd::make_unexpected(DynamicError::DivideByZero);
     }

--- a/src/rdf4cpp/datatypes/xsd/time/DayTimeDuration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/DayTimeDuration.cpp
@@ -148,23 +148,15 @@ nonstd::expected<capabilities::Subtype<xsd_dayTimeDuration>::cpp_type, DynamicEr
 template<>
 nonstd::expected<capabilities::Duration<xsd_dayTimeDuration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_dayTimeDuration>::duration_add(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto r = util::to_checked(lhs) + util::to_checked(rhs);
-    if (r.count().is_invalid()) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
-    }
-
-    return util::from_checked(r);
+    auto r = rdf4cpp::util::to_checked(lhs) + rdf4cpp::util::to_checked(rhs);
+    return util::optional_to_overflow(rdf4cpp::util::from_checked(r));
 }
 
 template<>
 nonstd::expected<capabilities::Duration<xsd_dayTimeDuration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_dayTimeDuration>::duration_sub(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto r = util::to_checked(lhs) - util::to_checked(rhs);
-    if (r.count().is_invalid()) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
-    }
-
-    return util::from_checked(r);
+    auto r = rdf4cpp::util::to_checked(lhs) - rdf4cpp::util::to_checked(rhs);
+    return util::optional_to_overflow(rdf4cpp::util::from_checked(r));
 }
 
 template<>
@@ -182,7 +174,8 @@ template<>
 nonstd::expected<capabilities::Duration<xsd_dayTimeDuration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_dayTimeDuration>::duration_scalar_mul(cpp_type const &dur, duration_scalar_cpp_type const &scalar) noexcept {
     auto r = std::round(static_cast<double>(dur.count()) * scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(r)) {
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, i64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
 
@@ -197,11 +190,12 @@ capabilities::Duration<xsd_dayTimeDuration>::duration_scalar_div(cpp_type const 
     }
 
     auto r = std::round(static_cast<double>(dur.count()) / scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(r)) {
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, i64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
 
-    return std::chrono::nanoseconds{static_cast<int64_t>(r)};
+    return std::chrono::nanoseconds{i64};
 }
 
 #endif

--- a/src/rdf4cpp/datatypes/xsd/time/Duration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Duration.cpp
@@ -189,10 +189,10 @@ capabilities::Inlineable<xsd_duration>::cpp_type capabilities::Inlineable<xsd_du
 template<>
 std::partial_ordering capabilities::Comparable<xsd_duration>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     static constexpr std::array<rdf4cpp::TimePoint, 4> to_compare{
-            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1696}, std::chrono::month{9}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
-            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1697}, std::chrono::month{2}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
-            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{3}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
-            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{7}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1696}, std::chrono::month{9}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1697}, std::chrono::month{2}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{3}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{7}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
     };
     auto cmp = [lhs, rhs](const rdf4cpp::TimePoint& tp) noexcept {
         try {

--- a/src/rdf4cpp/datatypes/xsd/time/Duration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Duration.cpp
@@ -189,10 +189,10 @@ capabilities::Inlineable<xsd_duration>::cpp_type capabilities::Inlineable<xsd_du
 template<>
 std::partial_ordering capabilities::Comparable<xsd_duration>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     static constexpr std::array<rdf4cpp::TimePoint, 4> to_compare{
-            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1696}, std::chrono::month{9}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
-            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1697}, std::chrono::month{2}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
-            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{3}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
-            rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{7}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1696}, std::chrono::month{9}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1697}, std::chrono::month{2}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{3}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
+            *rdf4cpp::util::construct_timepoint(YearMonthDay{Year{1903}, std::chrono::month{7}, std::chrono::day{1}}, std::chrono::milliseconds{0}),
     };
     auto cmp = [lhs, rhs](const rdf4cpp::TimePoint& tp) noexcept {
         try {
@@ -214,8 +214,8 @@ std::partial_ordering capabilities::Comparable<xsd_duration>::compare(cpp_type c
 template<>
 nonstd::expected<capabilities::Duration<xsd_duration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_duration>::duration_add(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto mon = util::to_checked(lhs.first) + util::to_checked(rhs.first);
-    auto nanos = util::to_checked(lhs.second) + util::to_checked(rhs.second);
+    auto mon = rdf4cpp::util::to_checked(lhs.first) + rdf4cpp::util::to_checked(rhs.first);
+    auto nanos = rdf4cpp::util::to_checked(lhs.second) + rdf4cpp::util::to_checked(rhs.second);
     if (mon.count().is_invalid() || nanos.count().is_invalid()) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
@@ -225,14 +225,14 @@ capabilities::Duration<xsd_duration>::duration_add(cpp_type const &lhs, cpp_type
     if (mon > std::chrono::months{0} && nanos < std::chrono::nanoseconds{0}) {
         return nonstd::make_unexpected(DynamicError::Unsupported);
     }
-    return std::make_pair(util::from_checked(mon), util::from_checked(nanos));
+    return std::make_pair(*rdf4cpp::util::from_checked(mon), *rdf4cpp::util::from_checked(nanos));
 }
 
 template<>
 nonstd::expected<capabilities::Duration<xsd_duration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_duration>::duration_sub(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto mon = util::to_checked(lhs.first) - util::to_checked(rhs.first);
-    auto nanos = util::to_checked(lhs.second) - util::to_checked(rhs.second);
+    auto mon = rdf4cpp::util::to_checked(lhs.first) - rdf4cpp::util::to_checked(rhs.first);
+    auto nanos = rdf4cpp::util::to_checked(lhs.second) - rdf4cpp::util::to_checked(rhs.second);
     if (mon.count().is_invalid() || nanos.count().is_invalid()) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
@@ -242,7 +242,7 @@ capabilities::Duration<xsd_duration>::duration_sub(cpp_type const &lhs, cpp_type
     if (mon > std::chrono::months{0} && nanos < std::chrono::nanoseconds{0}) {
         return nonstd::make_unexpected(DynamicError::Unsupported);
     }
-    return std::make_pair(util::from_checked(mon), util::from_checked(nanos));
+    return std::make_pair(*rdf4cpp::util::from_checked(mon), *rdf4cpp::util::from_checked(nanos));
 }
 
 template<>
@@ -255,15 +255,17 @@ template<>
 nonstd::expected<capabilities::Duration<xsd_duration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_duration>::duration_scalar_mul(cpp_type const &dur, duration_scalar_cpp_type const &scalar) noexcept {
     auto mon = std::round(static_cast<double>(dur.first.count()) * scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(mon)) {
+    int64_t m64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(mon, m64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
     auto nanos = std::round(static_cast<double>(dur.second.count()) * scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(nanos)) {
+    int64_t n64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(nanos, n64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
 
-    return std::make_pair(std::chrono::months{static_cast<int64_t>(mon)}, std::chrono::nanoseconds{static_cast<int64_t>(nanos)});
+    return std::make_pair(std::chrono::months{m64}, std::chrono::nanoseconds{n64});
 }
 
 template<>
@@ -274,15 +276,17 @@ capabilities::Duration<xsd_duration>::duration_scalar_div(cpp_type const &dur, d
     }
 
     auto mon = std::round(static_cast<double>(dur.first.count()) / scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(mon)) {
+    int64_t m64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(mon, m64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
     auto nanos = std::round(static_cast<double>(dur.second.count()) / scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(nanos)) {
+    int64_t n64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(nanos, n64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
 
-    return std::make_pair(std::chrono::months{static_cast<int64_t>(mon)}, std::chrono::nanoseconds{static_cast<int64_t>(nanos)});
+    return std::make_pair(std::chrono::months{m64}, std::chrono::nanoseconds{n64});
 }
 
 #endif

--- a/src/rdf4cpp/datatypes/xsd/time/Month.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Month.cpp
@@ -38,7 +38,7 @@ bool capabilities::Default<xsd_gMonth>::serialize_canonical_string(cpp_type cons
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gMonth>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto month_to_tp = [](std::chrono::month m) noexcept -> rdf4cpp::TimePoint {
+    auto month_to_tp = [](std::chrono::month m) noexcept -> std::optional<TimePoint> {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), m, std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(month_to_tp(lhs.first), lhs.second, month_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/Month.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Month.cpp
@@ -38,7 +38,7 @@ bool capabilities::Default<xsd_gMonth>::serialize_canonical_string(cpp_type cons
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gMonth>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto month_to_tp = [](std::chrono::month m) noexcept -> std::optional<TimePoint> {
+    auto month_to_tp = [](std::chrono::month m) noexcept -> TimePoint {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), m, std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(month_to_tp(lhs.first), lhs.second, month_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/MonthDay.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/MonthDay.cpp
@@ -61,7 +61,7 @@ capabilities::Inlineable<xsd_gMonthDay>::cpp_type capabilities::Inlineable<xsd_g
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gMonthDay>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto md_to_tp = [](std::chrono::month_day md) noexcept -> rdf4cpp::TimePoint {
+    auto md_to_tp = [](std::chrono::month_day md) noexcept -> std::optional<TimePoint> {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), md.month(), md.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(md_to_tp(lhs.first), lhs.second, md_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/MonthDay.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/MonthDay.cpp
@@ -61,7 +61,7 @@ capabilities::Inlineable<xsd_gMonthDay>::cpp_type capabilities::Inlineable<xsd_g
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gMonthDay>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto md_to_tp = [](std::chrono::month_day md) noexcept -> std::optional<TimePoint> {
+    auto md_to_tp = [](std::chrono::month_day md) noexcept -> TimePoint {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{rdf4cpp::util::time_point_replacement_date.year(), md.month(), md.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(md_to_tp(lhs.first), lhs.second, md_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/Time.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Time.cpp
@@ -77,7 +77,8 @@ std::partial_ordering capabilities::Comparable<xsd_time>::compare(cpp_type const
 template<>
 template<>
 capabilities::Promotable<xsd_time>::promoted_cpp_type<0> capabilities::Promotable<xsd_time>::promote<0>(cpp_type const &value) noexcept {
-    return std::make_pair(rdf4cpp::util::construct_timepoint(rdf4cpp::util::time_point_replacement_date, value.first), value.second);
+    // time_point_replacement_date can not cause an overflow
+    return std::make_pair(*rdf4cpp::util::construct_timepoint(rdf4cpp::util::time_point_replacement_date, value.first), value.second);
 }
 
 template<>
@@ -101,8 +102,15 @@ capabilities::Timepoint<xsd_time>::timepoint_duration_add(cpp_type const &tp, ti
     auto const super_dur = Subtype<timepoint_duration_operand_type::identifier>::into_supertype(dur);
 
     auto ret_tp = util::add_duration_to_date_time(super_tp.first, super_dur);
+    if (!ret_tp.has_value()) {
+        return nonstd::make_unexpected(ret_tp.error());
+    }
 
-    auto [_, time] = rdf4cpp::util::deconstruct_timepoint(ret_tp);
+    auto deconstructed = rdf4cpp::util::deconstruct_timepoint(*ret_tp);
+    if (!deconstructed.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    auto [_, time] = *deconstructed;
     return std::make_pair(std::chrono::duration_cast<std::chrono::nanoseconds>(time), super_tp.second);
 }
 
@@ -112,9 +120,25 @@ capabilities::Timepoint<xsd_time>::timepoint_duration_sub(cpp_type const &tp, ti
     auto const super_tp = Promotable<xsd_time>::promote(tp);
     auto const super_dur = Subtype<timepoint_duration_operand_type::identifier>::into_supertype(dur);
 
-    auto ret_tp = util::add_duration_to_date_time(super_tp.first, std::make_pair(-super_dur.first, -super_dur.second));
+    auto const sdur_month = rdf4cpp::util::from_checked(-rdf4cpp::util::to_checked(super_dur.first));
+    auto const sdur_nanos = rdf4cpp::util::from_checked(-rdf4cpp::util::to_checked((super_dur.second)));
+    if (!sdur_month.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    if (!sdur_nanos.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
 
-    auto [_, time] = rdf4cpp::util::deconstruct_timepoint(ret_tp);
+    auto ret_tp = util::add_duration_to_date_time(super_tp.first, std::make_pair(*sdur_month, *sdur_nanos));
+    if (!ret_tp.has_value()) {
+        return nonstd::make_unexpected(ret_tp.error());
+    }
+
+    auto deconstructed = rdf4cpp::util::deconstruct_timepoint(*ret_tp);
+    if (!deconstructed.has_value()) {
+        return nonstd::make_unexpected(datatypes::DynamicError::OverOrUnderFlow);
+    }
+    auto [_, time] = *deconstructed;
     return std::make_pair(std::chrono::duration_cast<std::chrono::nanoseconds>(time), super_tp.second);
 }
 

--- a/src/rdf4cpp/datatypes/xsd/time/Time.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Time.cpp
@@ -77,8 +77,7 @@ std::partial_ordering capabilities::Comparable<xsd_time>::compare(cpp_type const
 template<>
 template<>
 capabilities::Promotable<xsd_time>::promoted_cpp_type<0> capabilities::Promotable<xsd_time>::promote<0>(cpp_type const &value) noexcept {
-    // time_point_replacement_date can not cause an overflow
-    return std::make_pair(*rdf4cpp::util::construct_timepoint(rdf4cpp::util::time_point_replacement_date, value.first), value.second);
+    return std::make_pair(rdf4cpp::util::construct_timepoint(rdf4cpp::util::time_point_replacement_date, value.first), value.second);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/time/Year.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Year.cpp
@@ -26,14 +26,10 @@ bool capabilities::Default<xsd_gYear>::serialize_canonical_string(cpp_type const
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gYear>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    try {
-        auto year_to_tp = [](Year const &t) -> rdf4cpp::TimePoint {
-            return rdf4cpp::util::construct_timepoint(YearMonthDay{t, rdf4cpp::util::time_point_replacement_date.month(), rdf4cpp::util::time_point_replacement_date.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
-        };
-        return registry::util::compare_time_points(year_to_tp(lhs.first), lhs.second, year_to_tp(rhs.first), rhs.second);
-    } catch (std::overflow_error const &) {
-        return std::partial_ordering::unordered;
-    }
+    auto year_to_tp = [](Year const &t) -> std::optional<TimePoint> {
+        return rdf4cpp::util::construct_timepoint(YearMonthDay{t, rdf4cpp::util::time_point_replacement_date.month(), rdf4cpp::util::time_point_replacement_date.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
+    };
+    return registry::util::compare_time_points(year_to_tp(lhs.first), lhs.second, year_to_tp(rhs.first), rhs.second);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/time/Year.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/Year.cpp
@@ -26,7 +26,7 @@ bool capabilities::Default<xsd_gYear>::serialize_canonical_string(cpp_type const
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gYear>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto year_to_tp = [](Year const &t) -> std::optional<TimePoint> {
+    auto year_to_tp = [](Year const &t) -> TimePoint {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{t, rdf4cpp::util::time_point_replacement_date.month(), rdf4cpp::util::time_point_replacement_date.day()}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(year_to_tp(lhs.first), lhs.second, year_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/YearMonth.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/YearMonth.cpp
@@ -46,11 +46,12 @@ std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_gYear
         return std::nullopt;
     }
     auto const yearint = static_cast<int64_t>(value.first.year());
-    if (!util::fits_into<int16_t>(yearint)) [[unlikely]] {
+    int16_t yint16;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(yearint, yint16)) [[unlikely]] {
         return std::nullopt;
     }
-    return util::pack<storage::identifier::LiteralID>(InliningHelperYearMonth{static_cast<int16_t>(yearint),
-                                                                                static_cast<uint8_t>(static_cast<unsigned int>(value.first.month()))});
+    return util::pack<storage::identifier::LiteralID>(InliningHelperYearMonth{yint16,
+                                                                              static_cast<uint8_t>(static_cast<unsigned int>(value.first.month()))});
 }
 
 template<>
@@ -61,7 +62,7 @@ capabilities::Inlineable<xsd_gYearMonth>::cpp_type capabilities::Inlineable<xsd_
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gYearMonth>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto ym_to_tp = [](YearMonth const & t) -> rdf4cpp::TimePoint {
+    auto ym_to_tp = [](YearMonth const &t) -> std::optional<TimePoint> {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{t.year(), t.month(), std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(ym_to_tp(lhs.first), lhs.second, ym_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/YearMonth.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/YearMonth.cpp
@@ -62,7 +62,7 @@ capabilities::Inlineable<xsd_gYearMonth>::cpp_type capabilities::Inlineable<xsd_
 
 template<>
 std::partial_ordering capabilities::Comparable<xsd_gYearMonth>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto ym_to_tp = [](YearMonth const &t) -> std::optional<TimePoint> {
+    auto ym_to_tp = [](YearMonth const &t) -> TimePoint {
         return rdf4cpp::util::construct_timepoint(YearMonthDay{t.year(), t.month(), std::chrono::last}, rdf4cpp::util::time_point_replacement_time_of_day);
     };
     return registry::util::compare_time_points(ym_to_tp(lhs.first), lhs.second, ym_to_tp(rhs.first), rhs.second);

--- a/src/rdf4cpp/datatypes/xsd/time/YearMonthDuration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/YearMonthDuration.cpp
@@ -108,23 +108,15 @@ nonstd::expected<capabilities::Subtype<xsd_yearMonthDuration>::cpp_type, Dynamic
 template<>
 nonstd::expected<capabilities::Duration<xsd_yearMonthDuration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_yearMonthDuration>::duration_add(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto r = util::to_checked(lhs) + util::to_checked(rhs);
-    if (r.count().is_invalid()) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
-    }
-
-    return util::from_checked(r);
+    auto r = rdf4cpp::util::to_checked(lhs) + rdf4cpp::util::to_checked(rhs);
+    return util::optional_to_overflow(rdf4cpp::util::from_checked(r));
 }
 
 template<>
 nonstd::expected<capabilities::Duration<xsd_yearMonthDuration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_yearMonthDuration>::duration_sub(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto r = util::to_checked(lhs) - util::to_checked(rhs);
-    if (r.count().is_invalid()) {
-        return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
-    }
-
-    return util::from_checked(r);
+    auto r = rdf4cpp::util::to_checked(lhs) - rdf4cpp::util::to_checked(rhs);
+    return util::optional_to_overflow(rdf4cpp::util::from_checked(r));
 }
 
 template<>
@@ -142,11 +134,12 @@ template<>
 nonstd::expected<capabilities::Duration<xsd_yearMonthDuration>::cpp_type, DynamicError>
 capabilities::Duration<xsd_yearMonthDuration>::duration_scalar_mul(cpp_type const &dur, duration_scalar_cpp_type const &scalar) noexcept {
     auto r = std::round(static_cast<double>(dur.count()) * scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(r)) {
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, i64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
 
-    return std::chrono::months{static_cast<int64_t>(r)};
+    return std::chrono::months{i64};
 }
 
 template<>
@@ -157,11 +150,12 @@ capabilities::Duration<xsd_yearMonthDuration>::duration_scalar_div(cpp_type cons
     }
 
     auto r = std::round(static_cast<double>(dur.count()) / scalar);
-    if (!datatypes::registry::util::fits_into<int64_t>(r)) {
+    int64_t i64;
+    if (rdf4cpp::util::detail::cast_checked<rdf4cpp::util::detail::OverflowMode::Checked>(r, i64)) {
         return nonstd::make_unexpected(DynamicError::OverOrUnderFlow);
     }
 
-    return std::chrono::months{static_cast<int64_t>(r)};
+    return std::chrono::months{i64};
 }
 
 #endif

--- a/src/rdf4cpp/datatypes/xsd/time/YearMonthDuration.cpp
+++ b/src/rdf4cpp/datatypes/xsd/time/YearMonthDuration.cpp
@@ -130,7 +130,7 @@ capabilities::Duration<xsd_yearMonthDuration>::duration_sub(cpp_type const &lhs,
 template<>
 nonstd::expected<capabilities::Duration<xsd_yearMonthDuration>::duration_div_result_cpp_type, DynamicError>
 capabilities::Duration<xsd_yearMonthDuration>::duration_div(cpp_type const &lhs, cpp_type const &rhs) noexcept {
-    auto r = BigDecimal<>{lhs.count(), 0}.div_checked(BigDecimal<>{rhs.count(), 0}, 1000);
+    auto r = Decimal128{lhs.count(), 0}.div_checked(Decimal128{rhs.count(), 0}, 1000);
     if (!r.has_value()) {
         return nonstd::make_unexpected(DynamicError::DivideByZero);
     }

--- a/src/rdf4cpp/util/CheckedInt.hpp
+++ b/src/rdf4cpp/util/CheckedInt.hpp
@@ -1,13 +1,15 @@
 #ifndef RDF4CPP_CHECKEDINT_HPP
 #define RDF4CPP_CHECKEDINT_HPP
 
+#include <rdf4cpp/util/Int128.hpp>
+
 namespace rdf4cpp::util {
 /**
  * Wraps an integer type and keeps track of Overflows and similar Undefined Behavior.
  * Designed to be used in std::chrono::duration, but may be used standalone.
  * @tparam I Integer type to wrap
  */
-template<std::integral I>
+template<typename I>
 struct CheckedIntegral {
 private:
     I value;
@@ -46,10 +48,13 @@ public:
             return std::partial_ordering::unordered;
         return this->value <=> other.value;
     }
+    constexpr bool operator==(const CheckedIntegral &other) const noexcept {
+        return (*this <=> other) == std::partial_ordering::equivalent;
+    }
 
     constexpr CheckedIntegral &operator+=(const CheckedIntegral &other) noexcept {
         this->invalid |= other.invalid;
-        this->invalid |= __builtin_add_overflow(this->value, other.value, &this->value);
+        this->invalid |= detail::add_checked<detail::OverflowMode::Checked>(this->value, other.value, this->value);
         return *this;
     }
     constexpr CheckedIntegral operator+(const CheckedIntegral &other) const noexcept {
@@ -59,7 +64,7 @@ public:
     }
     constexpr CheckedIntegral &operator-=(const CheckedIntegral &other) noexcept {
         this->invalid |= other.invalid;
-        this->invalid |= __builtin_sub_overflow(this->value, other.value, &this->value);
+        this->invalid |= detail::sub_checked<detail::OverflowMode::Checked>(this->value, other.value, this->value);
         return *this;
     }
     constexpr CheckedIntegral operator-(const CheckedIntegral &other) const noexcept {
@@ -67,9 +72,12 @@ public:
         r -= other;
         return r;
     }
+    constexpr CheckedIntegral operator-() const noexcept {
+        return CheckedIntegral<I>{I{0}} - *this;
+    }
     constexpr CheckedIntegral &operator*=(const CheckedIntegral &other) noexcept {
         this->invalid |= other.invalid;
-        this->invalid |= __builtin_mul_overflow(this->value, other.value, &this->value);
+        this->invalid |= detail::mul_checked<detail::OverflowMode::Checked>(this->value, other.value, this->value);
         return *this;
     }
     constexpr CheckedIntegral operator*(const CheckedIntegral &other) const noexcept {
@@ -90,6 +98,19 @@ public:
         r /= other;
         return r;
     }
+    constexpr CheckedIntegral &operator%=(const CheckedIntegral &other) noexcept {
+        if (this->invalid || other.invalid || other.value == 0) {
+            this->invalid = true;
+            return *this;
+        }
+        this->value = this->value % other.value;
+        return *this;
+    }
+    constexpr CheckedIntegral operator%(const CheckedIntegral &other) const noexcept {
+        CheckedIntegral r = *this;
+        r %= other;
+        return r;
+    }
 
     friend constexpr CheckedIntegral abs(CheckedIntegral const &val) noexcept {
         if constexpr (std::is_unsigned_v<I>) {
@@ -100,12 +121,36 @@ public:
             }
 
             CheckedIntegral ret{0, val.invalid};
-            ret.invalid |= __builtin_sub_overflow(0, val.value, &ret.value);
+            ret.invalid |= detail::sub_checked<detail::OverflowMode::Checked>(I{0}, val.value, ret.value);
             return ret;
         }
     }
+
+    template<typename To>
+    constexpr CheckedIntegral<To> checked_cast() const noexcept {
+        To r = 0;
+        bool inv = detail::cast_checked<detail::OverflowMode::Checked>(value, r);
+        return {r, inv || invalid};
+    }
+
+    template<typename From>
+    requires std::convertible_to<From, I>
+    constexpr CheckedIntegral(CheckedIntegral<From> f) : CheckedIntegral(f.template checked_cast<I>()) {} // chrono expects integer types to be implicitly convertible
+    template<typename From>
+    requires (!std::convertible_to<From, I>)
+    constexpr explicit CheckedIntegral(CheckedIntegral<From> f) : CheckedIntegral(f.template checked_cast<I>()) {}
 };
+static_assert(std::convertible_to<rdf4cpp::util::CheckedIntegral<__int128>, rdf4cpp::util::CheckedIntegral<int64_t>>);
 
 }  // namespace rdf4cpp::util
+
+template<typename A, typename B>
+struct std::common_type<rdf4cpp::util::CheckedIntegral<A>, rdf4cpp::util::CheckedIntegral<B>> {
+    using type = rdf4cpp::util::CheckedIntegral<typename std::common_type<A, B>::type>;
+};
+static_assert(std::same_as<std::common_type<rdf4cpp::util::CheckedIntegral<__int128>, rdf4cpp::util::CheckedIntegral<int64_t>>::type,
+                           rdf4cpp::util::CheckedIntegral<__int128>>);
+static_assert(std::same_as<std::common_type<rdf4cpp::util::CheckedIntegral<__int128>, rdf4cpp::util::CheckedIntegral<int64_t>, std::intmax_t>::type,
+                           rdf4cpp::util::CheckedIntegral<__int128>>);
 
 #endif  //RDF4CPP_CHECKEDINT_HPP

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -11,6 +11,7 @@ namespace rdf4cpp::util {
 #else
     using Int128 = boost::multiprecision::checked_int128_t;
 #endif
+    using BigInt = Int128;
 
     // string -> int128 can be found in CharConvExt
 

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -8,10 +8,8 @@
 namespace rdf4cpp::util {
 #ifdef __SIZEOF_INT128__
     using Int128 = __int128;
-    using UInt128 = unsigned __int128;
 #else
     using Int128 = boost::multiprecision::checked_int128_t;
-    using UInt128 = boost::multiprecision::checked_uint128_t;
 #endif
 
     // string -> int128 can be found in CharConvExt
@@ -49,6 +47,12 @@ namespace rdf4cpp::util {
     }
 #endif
 
+    inline bool to_chars_canonical(boost::multiprecision::checked_int128_t const &value, writer::BufWriterParts const writer) noexcept {
+        std::stringstream s{};
+        s << value;
+        return writer::write_str(s.view(), writer);
+    }
+
     namespace detail {
         enum struct OverflowMode {
             Checked,
@@ -60,8 +64,11 @@ namespace rdf4cpp::util {
         template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
         using cpp_int_unchecked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::unchecked, Alloc>>;
 
+        template<typename T>
+        concept IntegralExt = std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>;
+
         template<OverflowMode m, typename T>
-        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        requires IntegralExt<T>
         static constexpr bool add_checked(T const &a, T const &b, T &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
                 return __builtin_add_overflow(a, b, &result);
@@ -111,7 +118,7 @@ namespace rdf4cpp::util {
 
 
         template<OverflowMode m, typename T>
-        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        requires IntegralExt<T>
         static constexpr bool sub_checked(T const &a, T const &b, T &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
                 return __builtin_sub_overflow(a, b, &result);
@@ -161,7 +168,7 @@ namespace rdf4cpp::util {
 
 
         template<OverflowMode m, typename T>
-        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        requires IntegralExt<T>
         static constexpr bool mul_checked(T const &a, T const &b, T &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
                 return __builtin_mul_overflow(a, b, &result);
@@ -211,7 +218,7 @@ namespace rdf4cpp::util {
 
 
         template<OverflowMode m, typename T>
-        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        requires IntegralExt<T>
         static constexpr bool pow_checked(T const &a, unsigned int b, T &result) noexcept {
             T r = 1;
             bool over = false;
@@ -259,17 +266,109 @@ namespace rdf4cpp::util {
                 return false;
             }
         }
+
+
+        template<OverflowMode m, typename To, typename From>
+        requires IntegralExt<To> && IntegralExt<From>
+        static constexpr bool cast_checked(const From &f, To &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
+                    if (std::numeric_limits<To>::min() > f || f > std::numeric_limits<To>::max()) {
+                        return true;
+                    }
+                }
+                else if constexpr (std::numeric_limits<To>::is_signed) {
+                    if (f < 0 || std::make_unsigned_t<From>(f) > std::numeric_limits<To>::max()) {
+                        return true;
+                    }
+                }
+                else {
+                    if (f > std::numeric_limits<To>::max()) {
+                        return true;
+                    }
+                }
+            }
+            result = static_cast<To>(f);
+            return false;
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
+        static constexpr bool cast_checked(const cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &f, To &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                try {
+                    result = static_cast<To>(f);
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            }
+            result = static_cast<To>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
+            return false;
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
+        static constexpr bool cast_checked(const cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &f, To &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                try {
+                    result = static_cast<To>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            }
+            result = static_cast<To>(f);
+            return false;
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
+        static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                try {
+                    result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            }
+            result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
+            return false;
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
+        static constexpr bool cast_checked(From const &f, cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                try {
+                    result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            }
+            result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f);
+            return false;
+        }
+
     }  // namespace detail
 }  // namespace rdf4cpp::util
 
 #ifdef __SIZEOF_INT128__
 
 template<typename Policy>
-struct dice::hash::dice_hash_overload<Policy, rdf4cpp::util::Int128> {
-    static size_t dice_hash(rdf4cpp::util::Int128 const &x) noexcept {
+struct dice::hash::dice_hash_overload<Policy, __int128> {
+    static size_t dice_hash(__int128 const &x) noexcept {
         return dice::hash::dice_hash_templates<Policy>::dice_hash(std::bit_cast<std::array<int64_t, 2>>(x));
     }
 };
+inline std::ostream &operator<<(std::ostream &str, __int128 const &bn) {
+    rdf4cpp::writer::BufOStreamWriter w{str};
+    rdf4cpp::util::to_chars_canonical(bn, w);
+    w.finalize();
+    return str;
+}
 #endif
 
 #endif  //RDF4CPP_INT128_HPP

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -12,6 +12,12 @@ namespace rdf4cpp::util {
     using Int128 = boost::multiprecision::checked_int128_t;
 #endif
 
+#ifdef RDF4CPP_USE_UNLIMITED_DATATYPES
+    using BigInt = boost::multiprecision::checked_cpp_int;
+#else
+    using BigInt = Int128;
+#endif
+
     // string -> int128 can be found in CharConvExt
 
 #ifdef __SIZEOF_INT128__
@@ -47,12 +53,6 @@ namespace rdf4cpp::util {
     }
 #endif
 
-    inline bool to_chars_canonical(boost::multiprecision::checked_int128_t const &value, writer::BufWriterParts const writer) noexcept {
-        std::stringstream s{};
-        s << value;
-        return writer::write_str(s.view(), writer);
-    }
-
     namespace detail {
         enum struct OverflowMode {
             Checked,
@@ -66,6 +66,8 @@ namespace rdf4cpp::util {
 
         template<typename T>
         concept IntegralExt = std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>;
+        template<typename T>
+        concept BoostNumber = std::same_as<T, boost::multiprecision::number<typename T::backend_type, T::et>>;
 
         template<OverflowMode m, typename T>
         requires IntegralExt<T>
@@ -365,6 +367,14 @@ namespace rdf4cpp::util {
         }
 
     }  // namespace detail
+
+    template<detail::BoostNumber T>
+    bool to_chars_canonical(T const &value, writer::BufWriterParts const writer) noexcept {
+        std::stringstream s{};
+        s << value;
+        return writer::write_str(s.view(), writer);
+    }
+
 }  // namespace rdf4cpp::util
 
 #ifdef __SIZEOF_INT128__
@@ -373,6 +383,12 @@ template<typename Policy>
 struct dice::hash::dice_hash_overload<Policy, __int128> {
     static size_t dice_hash(__int128 const &x) noexcept {
         return dice::hash::dice_hash_templates<Policy>::dice_hash(std::bit_cast<std::array<int64_t, 2>>(x));
+    }
+};
+template<typename Policy, typename N, boost::multiprecision::expression_template_option et>
+struct dice::hash::dice_hash_overload<Policy, boost::multiprecision::number<N, et>> {
+    static size_t dice_hash(boost::multiprecision::number<N, et> const &x) noexcept {
+        return dice::hash::dice_hash_templates<Policy>::dice_hash(::boost::multiprecision::hash_value(x));
     }
 };
 inline std::ostream &operator<<(std::ostream &str, __int128 const &bn) {

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -39,9 +39,30 @@ namespace rdf4cpp {
                 return upper;
             }
 
-            first = upper.ptr;
+            if (last - upper.ptr < std::numeric_limits<uint64_t>::digits10) {
+                return { last, std::errc::value_too_large };
+            }
 
-            std::to_chars_result lower = std::to_chars(first, last, static_cast<uint64_t>(val % max_pow10));
+            std::array<char, std::numeric_limits<uint64_t>::digits10+1> buff;
+            std::to_chars_result lower = std::to_chars(buff.data(), buff.data()+buff.size(), static_cast<uint64_t>(val % max_pow10));
+
+            if (lower.ec != std::errc{}) {
+                return lower;
+            }
+
+            const auto written = lower.ptr - buff.data();
+            const auto n_zeroes = std::numeric_limits<uint64_t>::digits10 - written;
+
+            char* curr = upper.ptr;
+            RDF4CPP_DEBUG_ASSERT(last - curr >= n_zeroes);
+            std::memset(curr, '0', n_zeroes);
+            curr += n_zeroes;
+            RDF4CPP_DEBUG_ASSERT(last - curr >= written);
+            std::memcpy(curr, buff.data(), written);
+            curr += written;
+
+            lower.ptr = curr;
+
             return lower;
         }
         inline std::to_chars_result to_chars(char *first, char *last, __int128 val) noexcept {

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -6,292 +6,291 @@
 // and return true, iff the operation failed.
 
 #include <boost/multiprecision/cpp_int.hpp>
-#include <rdf4cpp/writer/BufWriter.hpp>
 #include <dice/hash.hpp>
+#include <rdf4cpp/writer/BufWriter.hpp>
 
-namespace rdf4cpp::util {
+namespace rdf4cpp {
 #ifdef __SIZEOF_INT128__
     using Int128 = __int128;
 #else
     using Int128 = boost::multiprecision::checked_int128_t;
 #endif
 
-    // string -> int128 can be found in CharConvExt
+    namespace util {
+        // string -> int128 can be found in CharConvExt
 
 #ifdef __SIZEOF_INT128__
-    inline std::to_chars_result to_chars(char *first, char *last, unsigned __int128 val) noexcept {
-        static constexpr unsigned __int128 max_pow10 = []() {
-            auto n = std::numeric_limits<uint64_t>::digits10;
-            unsigned __int128 d = 1;
-            for (int i = 0; i < n; ++i) {
-                d = d * 10;
+        inline std::to_chars_result to_chars(char *first, char *last, unsigned __int128 val) noexcept {
+            static constexpr unsigned __int128 max_pow10 = []() {
+                auto n = std::numeric_limits<uint64_t>::digits10;
+                unsigned __int128 d = 1;
+                for (int i = 0; i < n; ++i) {
+                    d = d * 10;
+                }
+                return d;
+            }();
+
+            if (val <= std::numeric_limits<uint64_t>::max()) {
+                return std::to_chars(first, last, static_cast<uint64_t>(val));
             }
-            return d;
-        }();
 
-        if (val <= std::numeric_limits<uint64_t>::max()) {
-            return std::to_chars(first, last, static_cast<uint64_t>(val));
+            std::to_chars_result upper = to_chars(first, last, val / max_pow10);
+            if (upper.ec != std::errc{}) {
+                return upper;
+            }
+
+            first = upper.ptr;
+
+            std::to_chars_result lower = std::to_chars(first, last, static_cast<uint64_t>(val % max_pow10));
+            return lower;
         }
+        inline std::to_chars_result to_chars(char *first, char *last, __int128 val) noexcept {
+            if (val >= 0) {
+                return to_chars(first, last, static_cast<unsigned __int128>(val));
+            }
 
-        std::to_chars_result upper = to_chars(first, last, val / max_pow10);
-        if (upper.ec != std::errc{}) {
-            return upper;
-        }
+            if (val == std::numeric_limits<__int128>::min()) [[unlikely]] {
+                static constexpr std::string_view data = "-170141183460469231731687303715884105728";
+                static constexpr auto write = data;
+                if ((last - first) < static_cast<int64_t>(write.size())) {
+                    return std::to_chars_result{.ptr = first, .ec = std::errc::value_too_large};
+                }
+                std::memcpy(first, write.data(), write.size());
+                return std::to_chars_result{.ptr = first + write.size(), .ec = std::errc{}};
+            }
 
-        first = upper.ptr;
-
-        std::to_chars_result lower = std::to_chars(first, last, static_cast<uint64_t>(val % max_pow10));
-        return lower;
-    }
-    inline std::to_chars_result to_chars(char *first, char *last, __int128 val) noexcept {
-        if (val >= 0) {
-            return to_chars(first, last, static_cast<unsigned __int128>(val));
-        }
-
-        if (val == std::numeric_limits<__int128>::min()) [[unlikely]] {
-            static constexpr std::string_view data = "-170141183460469231731687303715884105728";
-            static constexpr auto write = data;
-            if ((last - first) < static_cast<int64_t>(write.size())) {
+            if (first == last) [[unlikely]] {
                 return std::to_chars_result{.ptr = first, .ec = std::errc::value_too_large};
             }
-            std::memcpy(first, write.data(), write.size());
-            return std::to_chars_result{.ptr = first + write.size(), .ec = std::errc{}};
+
+            *first++ = '-';
+            return to_chars(first, last, static_cast<unsigned __int128>(-val));
         }
+        inline bool to_chars_canonical(__int128 const value, writer::BufWriterParts const writer) noexcept {
+            // +1 because of definition of digits10 https://en.cppreference.com/w/cpp/types/numeric_limits/digits10
+            // +1 for sign
+            static constexpr size_t buf_sz = std::numeric_limits<__int128>::digits10 + 1 + 1;
 
-        if (first == last) [[unlikely]] {
-            return std::to_chars_result{.ptr = first, .ec = std::errc::value_too_large};
+            std::array<char, buf_sz> buf;
+            std::to_chars_result const res = to_chars(buf.data(), buf.data() + buf.size(), value);
+
+            assert(res.ec == std::errc{});
+
+            std::string_view const s{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
+            return writer::write_str(s, writer);
         }
-
-        *first++ = '-';
-        return to_chars(first, last, static_cast<unsigned __int128>(-val));
-    }
-    inline bool to_chars_canonical(__int128 const value, writer::BufWriterParts const writer) noexcept {
-        // +1 because of definition of digits10 https://en.cppreference.com/w/cpp/types/numeric_limits/digits10
-        // +1 for sign
-        static constexpr size_t buf_sz = std::numeric_limits<__int128>::digits10 + 1 + 1;
-
-        std::array<char, buf_sz> buf;
-        std::to_chars_result const res = to_chars(buf.data(), buf.data() + buf.size(), value);
-
-        assert(res.ec == std::errc{});
-
-        std::string_view const s{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
-        return writer::write_str(s, writer);
-    }
 #endif
 
-    namespace detail {
-        enum struct OverflowMode {
-            Checked,
-            UndefinedBehavior,
-        };
+        namespace detail {
+            enum struct OverflowMode {
+                Checked,
+                UndefinedBehavior,
+            };
 
-        template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        using cpp_int_checked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::checked, Alloc>>;
-        template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        using cpp_int_unchecked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::unchecked, Alloc>>;
+            template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+            using cpp_int_checked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::checked, Alloc>>;
+            template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+            using cpp_int_unchecked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::unchecked, Alloc>>;
 
-        template<typename T>
-        concept IntegralExt = std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>;
-        template<typename T>
-        concept BoostNumber = std::same_as<T, boost::multiprecision::number<typename T::backend_type, T::et>>;
+            template<typename T>
+            concept IntegralExt = std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>;
+            template<typename T>
+            concept BoostNumber = std::same_as<T, boost::multiprecision::number<typename T::backend_type, T::et>>;
 
-        template<OverflowMode m, typename T>
-        requires IntegralExt<T>
-        static constexpr bool add_checked(T const &a, T const &b, T &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                return __builtin_add_overflow(a, b, &result);
-            } else {
-                result = a + b;
-                return false;
-            }
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool add_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                try {
+            template<OverflowMode m, typename T>
+            requires IntegralExt<T>
+            static constexpr bool add_checked(T const &a, T const &b, T &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    return __builtin_add_overflow(a, b, &result);
+                } else {
                     result = a + b;
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
+                    return false;
                 }
-                return false;
-            } else {
-                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
-                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} + Unc{b}};
-                return false;
             }
-        }
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+            static constexpr bool add_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if (m == OverflowMode::Checked) {
+                    try {
+                        result = a + b;
+                    } catch (std::overflow_error const &) {
+                        return true;
+                    } catch (std::range_error const &) {
+                        return true;
+                    }
+                    return false;
+                } else {
+                    using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                    result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} + Unc{b}};
+                    return false;
+                }
+            }
 
-        template<OverflowMode m, typename T>
-        requires IntegralExt<T>
-        static constexpr bool sub_checked(T const &a, T const &b, T &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                return __builtin_sub_overflow(a, b, &result);
-            } else {
-                result = a - b;
-                return false;
-            }
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool sub_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                try {
+            template<OverflowMode m, typename T>
+            requires IntegralExt<T>
+            static constexpr bool sub_checked(T const &a, T const &b, T &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    return __builtin_sub_overflow(a, b, &result);
+                } else {
                     result = a - b;
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
+                    return false;
                 }
-                return false;
-            } else {
-                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
-                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} - Unc{b}};
-                return false;
             }
-        }
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+            static constexpr bool sub_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if (m == OverflowMode::Checked) {
+                    try {
+                        result = a - b;
+                    } catch (std::overflow_error const &) {
+                        return true;
+                    } catch (std::range_error const &) {
+                        return true;
+                    }
+                    return false;
+                } else {
+                    using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                    result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} - Unc{b}};
+                    return false;
+                }
+            }
 
-        template<OverflowMode m, typename T>
-        requires IntegralExt<T>
-        static constexpr bool mul_checked(T const &a, T const &b, T &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                return __builtin_mul_overflow(a, b, &result);
-            } else {
-                result = a * b;
-                return false;
-            }
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool mul_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                try {
+            template<OverflowMode m, typename T>
+            requires IntegralExt<T>
+            static constexpr bool mul_checked(T const &a, T const &b, T &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    return __builtin_mul_overflow(a, b, &result);
+                } else {
                     result = a * b;
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
+                    return false;
                 }
-                return false;
-            } else {
-                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
-                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} * Unc{b}};
-                return false;
             }
-        }
-
-        template<OverflowMode m, typename T>
-        requires IntegralExt<T>
-        static constexpr bool pow_checked(T const &a, unsigned int b, T &result) noexcept {
-            T r = 1;
-            bool over = false;
-            for (unsigned int i = 0; i < b; ++i) {
-                over |= mul_checked<m, T>(r, a, r);
-            }
-            result = r;
-            return over;
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool pow_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          unsigned int b,
-                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                try {
-                    result = boost::multiprecision::pow(a, b);
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            } else {
-                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
-                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{boost::multiprecision::pow(Unc{a}, b)};
-                return false;
-            }
-        }
-
-        template<typename T>
-        struct MakeUnsigned {
-            using t = std::make_unsigned_t<T>;
-        };
-        template<>
-        struct MakeUnsigned<__int128> {
-            using t = unsigned __int128;
-        };
-        template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_int_check_type Checked, typename Alloc>
-        struct MakeUnsigned<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::signed_magnitude, Checked, Alloc>>> {
-            using t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::unsigned_magnitude, Checked, Alloc>>;
-        };
-        template<OverflowMode m, typename To, typename From>
-        requires IntegralExt<To> && IntegralExt<From>
-        static constexpr bool cast_checked(const From &f, To &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
-                    if (std::numeric_limits<To>::min() > f || f > std::numeric_limits<To>::max()) {
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+            static constexpr bool mul_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if (m == OverflowMode::Checked) {
+                    try {
+                        result = a * b;
+                    } catch (std::overflow_error const &) {
+                        return true;
+                    } catch (std::range_error const &) {
                         return true;
                     }
+                    return false;
+                } else {
+                    using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                    result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} * Unc{b}};
+                    return false;
                 }
-                else if constexpr (std::numeric_limits<From>::is_signed) {
-                    if (f < 0 || static_cast<typename MakeUnsigned<From>::t>(f) > std::numeric_limits<To>::max()) {
+            }
+
+            template<OverflowMode m, typename T>
+            requires IntegralExt<T>
+            static constexpr bool pow_checked(T const &a, unsigned int b, T &result) noexcept {
+                T r = 1;
+                bool over = false;
+                for (unsigned int i = 0; i < b; ++i) {
+                    over |= mul_checked<m, T>(r, a, r);
+                }
+                result = r;
+                return over;
+            }
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+            static constexpr bool pow_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                              unsigned int b,
+                                              cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if (m == OverflowMode::Checked) {
+                    try {
+                        result = boost::multiprecision::pow(a, b);
+                    } catch (std::overflow_error const &) {
+                        return true;
+                    } catch (std::range_error const &) {
                         return true;
                     }
+                    return false;
+                } else {
+                    using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                    result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{boost::multiprecision::pow(Unc{a}, b)};
+                    return false;
                 }
-                else {
-                    if (f > std::numeric_limits<To>::max()) {
-                        return true;
+            }
+
+            template<typename T>
+            struct MakeUnsigned {
+                using t = std::make_unsigned_t<T>;
+            };
+            template<>
+            struct MakeUnsigned<__int128> {
+                using t = unsigned __int128;
+            };
+            template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_int_check_type Checked, typename Alloc>
+            struct MakeUnsigned<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::signed_magnitude, Checked, Alloc>>> {
+                using t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::unsigned_magnitude, Checked, Alloc>>;
+            };
+            template<OverflowMode m, typename To, typename From>
+            requires IntegralExt<To> && IntegralExt<From>
+            static constexpr bool cast_checked(From const &f, To &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
+                        if (std::numeric_limits<To>::min() > f || f > std::numeric_limits<To>::max()) {
+                            return true;
+                        }
+                    } else if constexpr (std::numeric_limits<From>::is_signed) {
+                        if (f < 0 || static_cast<typename MakeUnsigned<From>::t>(f) > std::numeric_limits<To>::max()) {
+                            return true;
+                        }
+                    } else {
+                        if (f > std::numeric_limits<To>::max()) {
+                            return true;
+                        }
                     }
                 }
-            }
-            result = static_cast<To>(f);
-            return false;
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
-        static constexpr bool cast_checked(const cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &f, To &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                try {
-                    result = static_cast<To>(f);
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
+                result = static_cast<To>(f);
                 return false;
             }
-            result = static_cast<To>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
-            return false;
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
-        static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                try {
-                    result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
+            static constexpr bool cast_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &f, To &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    try {
+                        result = static_cast<To>(f);
+                    } catch (std::overflow_error const &) {
+                        return true;
+                    } catch (std::range_error const &) {
+                        return true;
+                    }
+                    return false;
                 }
+                result = static_cast<To>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
                 return false;
             }
-            result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
-            return false;
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
+            static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    try {
+                        result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
+                    } catch (std::overflow_error const &) {
+                        return true;
+                    } catch (std::range_error const &) {
+                        return true;
+                    }
+                    return false;
+                }
+                result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
+                return false;
+            }
+        }  // namespace detail
+
+        template<detail::BoostNumber T>
+        bool to_chars_canonical(T const &value, writer::BufWriterParts const writer) noexcept {
+            std::stringstream s{};
+            s << value;
+            return writer::write_str(s.view(), writer);
         }
-    }  // namespace detail
-
-    template<detail::BoostNumber T>
-    bool to_chars_canonical(T const &value, writer::BufWriterParts const writer) noexcept {
-        std::stringstream s{};
-        s << value;
-        return writer::write_str(s.view(), writer);
-    }
-
-}  // namespace rdf4cpp::util
+    }  // namespace util
+}  // namespace rdf4cpp
 
 #ifdef __SIZEOF_INT128__
 

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -74,7 +74,7 @@ namespace rdf4cpp {
             std::array<char, buf_sz> buf;
             std::to_chars_result const res = to_chars(buf.data(), buf.data() + buf.size(), value);
 
-            assert(res.ec == std::errc{});
+            RDF4CPP_ASSERT(res.ec == std::errc{});
 
             std::string_view const s{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
             return writer::write_str(s, writer);

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -305,8 +305,9 @@ namespace rdf4cpp::util {
         struct MakeUnsigned<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::signed_magnitude, Checked, Alloc>>> {
             using t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::unsigned_magnitude, Checked, Alloc>>;
         };
+        // TODO check double->int64 conversion
         template<OverflowMode m, typename To, typename From>
-        requires IntegralExt<To> && IntegralExt<From>
+        requires (IntegralExt<To> || std::floating_point<To>) && (IntegralExt<From> || std::floating_point<From>)
         static constexpr bool cast_checked(const From &f, To &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
                 if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
@@ -420,6 +421,15 @@ inline std::ostream &operator<<(std::ostream &str, __int128 const &bn) {
     w.finalize();
     return str;
 }
+template<>
+struct std::formatter<__int128> : std::formatter<std::string_view> {
+    inline auto format(__int128 const &p, format_context &ctx) const {
+        rdf4cpp::writer::BufOutputIteratorWriter w{ctx.out()};
+        rdf4cpp::util::to_chars_canonical(p, w);
+        w.finalize();
+        return w.buffer().iter;
+    }
+};
 #endif
 
 #endif  //RDF4CPP_INT128_HPP

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -268,6 +268,18 @@ namespace rdf4cpp::util {
         }
 
 
+        template<typename T>
+        struct MakeUnsigned {
+            using t = std::make_unsigned_t<T>;
+        };
+        template<>
+        struct MakeUnsigned<__int128> {
+            using t = unsigned __int128;
+        };
+        template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_int_check_type Checked, typename Alloc>
+        struct MakeUnsigned<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::signed_magnitude, Checked, Alloc>>> {
+            using t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::unsigned_magnitude, Checked, Alloc>>;
+        };
         template<OverflowMode m, typename To, typename From>
         requires IntegralExt<To> && IntegralExt<From>
         static constexpr bool cast_checked(const From &f, To &result) noexcept {
@@ -277,8 +289,8 @@ namespace rdf4cpp::util {
                         return true;
                     }
                 }
-                else if constexpr (std::numeric_limits<To>::is_signed) {
-                    if (f < 0 || std::make_unsigned_t<From>(f) > std::numeric_limits<To>::max()) {
+                else if constexpr (std::numeric_limits<From>::is_signed) {
+                    if (f < 0 || static_cast<typename MakeUnsigned<From>::t>(f) > std::numeric_limits<To>::max()) {
                         return true;
                     }
                 }

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -1,6 +1,10 @@
 #ifndef RDF4CPP_INT128_HPP
 #define RDF4CPP_INT128_HPP
 
+// checked arithmetic functions returning a boolean to indicate failure
+// follow the example of https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html
+// and return true, iff the operation failed.
+
 #include <boost/multiprecision/cpp_int.hpp>
 #include <rdf4cpp/writer/BufWriter.hpp>
 #include <dice/hash.hpp>
@@ -121,26 +125,6 @@ namespace rdf4cpp::util {
                 return false;
             }
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool add_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &b,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
-                try {
-                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{C{a} + C{b}};
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            } else {
-                result = a + b;
-                return false;
-            }
-        }
-
 
         template<OverflowMode m, typename T>
         requires IntegralExt<T>
@@ -171,26 +155,6 @@ namespace rdf4cpp::util {
                 return false;
             }
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool sub_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &b,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
-                try {
-                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{C{a} - C{b}};
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            } else {
-                result = a - b;
-                return false;
-            }
-        }
-
 
         template<OverflowMode m, typename T>
         requires IntegralExt<T>
@@ -221,26 +185,6 @@ namespace rdf4cpp::util {
                 return false;
             }
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool mul_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &b,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
-                try {
-                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{C{a} * C{b}};
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            } else {
-                result = a * b;
-                return false;
-            }
-        }
-
 
         template<OverflowMode m, typename T>
         requires IntegralExt<T>
@@ -272,26 +216,6 @@ namespace rdf4cpp::util {
                 return false;
             }
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
-        static constexpr bool pow_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
-                                          unsigned int b,
-                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if (m == OverflowMode::Checked) {
-                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
-                try {
-                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{boost::multiprecision::pow(C{a}, b)};
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            } else {
-                result = boost::multiprecision::pow(a, b);
-                return false;
-            }
-        }
-
 
         template<typename T>
         struct MakeUnsigned {
@@ -343,21 +267,6 @@ namespace rdf4cpp::util {
             result = static_cast<To>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
             return false;
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
-        static constexpr bool cast_checked(const cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &f, To &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                try {
-                    result = static_cast<To>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            }
-            result = static_cast<To>(f);
-            return false;
-        }
         template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
         static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
@@ -373,22 +282,6 @@ namespace rdf4cpp::util {
             result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
             return false;
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
-        static constexpr bool cast_checked(From const &f, cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                try {
-                    result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
-                    return true;
-                }
-                return false;
-            }
-            result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f);
-            return false;
-        }
-
     }  // namespace detail
 
     template<detail::BoostNumber T>

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -1,0 +1,275 @@
+#ifndef RDF4CPP_INT128_HPP
+#define RDF4CPP_INT128_HPP
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <rdf4cpp/writer/BufWriter.hpp>
+#include <dice/hash.hpp>
+
+namespace rdf4cpp::util {
+#ifdef __SIZEOF_INT128__
+    using Int128 = __int128;
+    using UInt128 = unsigned __int128;
+#else
+    using Int128 = boost::multiprecision::checked_int128_t;
+    using UInt128 = boost::multiprecision::checked_uint128_t;
+#endif
+
+    // string -> int128 can be found in CharConvExt
+
+#ifdef __SIZEOF_INT128__
+    inline bool to_chars_canonical(__int128 value, writer::BufWriterParts const writer) noexcept {
+        if (value == 0) {
+            return writer::write_str("0", writer);
+        }
+        // +1 because of definition of digits10 https://en.cppreference.com/w/cpp/types/numeric_limits/digits10
+        // +1 for sign
+        static constexpr size_t buf_sz = std::numeric_limits<__int128>::digits10 + 1 + 1;
+
+        std::array<char, buf_sz> buf;
+
+        bool const neg = value < 0;
+        char *curr = buf.data() + buf.size();
+        while (value != 0) {
+            auto c = static_cast<int>(value % 10);
+            value = value / 10;
+            if (neg) {
+                c = -c;
+            }
+            --curr;
+            assert(curr >= buf.data());
+            *curr = static_cast<char>('0' + c);
+        }
+        if (neg) {
+            --curr;
+            assert(curr >= buf.data());
+            *curr = '-';
+        }
+
+        return writer::write_str(std::string_view(curr, buf.data() + buf.size()), writer);
+    }
+#endif
+
+    namespace detail {
+        enum struct OverflowMode {
+            Checked,
+            UndefinedBehavior,
+        };
+
+        template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        using cpp_int_checked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::checked, Alloc>>;
+        template<std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        using cpp_int_unchecked = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, boost::multiprecision::unchecked, Alloc>>;
+
+        template<OverflowMode m, typename T>
+        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        static constexpr bool add_checked(T const &a, T const &b, T &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                return __builtin_add_overflow(a, b, &result);
+            } else {
+                result = a + b;
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool add_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                try {
+                    result = a + b;
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} + Unc{b}};
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool add_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
+                try {
+                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{C{a} + C{b}};
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                result = a + b;
+                return false;
+            }
+        }
+
+
+        template<OverflowMode m, typename T>
+        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        static constexpr bool sub_checked(T const &a, T const &b, T &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                return __builtin_sub_overflow(a, b, &result);
+            } else {
+                result = a - b;
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool sub_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                try {
+                    result = a - b;
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} - Unc{b}};
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool sub_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
+                try {
+                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{C{a} - C{b}};
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                result = a - b;
+                return false;
+            }
+        }
+
+
+        template<OverflowMode m, typename T>
+        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        static constexpr bool mul_checked(T const &a, T const &b, T &result) noexcept {
+            if constexpr (m == OverflowMode::Checked) {
+                return __builtin_mul_overflow(a, b, &result);
+            } else {
+                result = a * b;
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool mul_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                try {
+                    result = a * b;
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{Unc{a} * Unc{b}};
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool mul_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &b,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
+                try {
+                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{C{a} * C{b}};
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                result = a * b;
+                return false;
+            }
+        }
+
+
+        template<OverflowMode m, typename T>
+        requires std::integral<T> || std::same_as<T, __int128> || std::same_as<T, unsigned __int128>
+        static constexpr bool pow_checked(T const &a, unsigned int b, T &result) noexcept {
+            T r = 1;
+            bool over = false;
+            for (unsigned int i = 0; i < b; ++i) {
+                over |= mul_checked<m, T>(r, a, r);
+            }
+            result = r;
+            return over;
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool pow_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          unsigned int b,
+                                          cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                try {
+                    result = boost::multiprecision::pow(a, b);
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                using Unc = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>;
+                result = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>{boost::multiprecision::pow(Unc{a}, b)};
+                return false;
+            }
+        }
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc>
+        static constexpr bool pow_checked(cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> const &a,
+                                          unsigned int b,
+                                          cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+            if (m == OverflowMode::Checked) {
+                using C = cpp_int_checked<MinBits, MaxBits, SignType, Alloc>;
+                try {
+                    result = cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>{boost::multiprecision::pow(C{a}, b)};
+                } catch (std::overflow_error const &) {
+                    return true;
+                } catch (std::range_error const &) {
+                    return true;
+                }
+                return false;
+            } else {
+                result = boost::multiprecision::pow(a, b);
+                return false;
+            }
+        }
+    }  // namespace detail
+}  // namespace rdf4cpp::util
+
+#ifdef __SIZEOF_INT128__
+
+template<typename Policy>
+struct dice::hash::dice_hash_overload<Policy, rdf4cpp::util::Int128> {
+    static size_t dice_hash(rdf4cpp::util::Int128 const &x) noexcept {
+        return dice::hash::dice_hash_templates<Policy>::dice_hash(std::bit_cast<std::array<int64_t, 2>>(x));
+    }
+};
+#endif
+
+#endif  //RDF4CPP_INT128_HPP

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -11,40 +11,68 @@ namespace rdf4cpp::util {
 #else
     using Int128 = boost::multiprecision::checked_int128_t;
 #endif
-    using BigInt = Int128;
 
     // string -> int128 can be found in CharConvExt
 
 #ifdef __SIZEOF_INT128__
-    inline bool to_chars_canonical(__int128 value, writer::BufWriterParts const writer) noexcept {
-        if (value == 0) {
-            return writer::write_str("0", writer);
+    inline std::to_chars_result to_chars(char *first, char *last, unsigned __int128 val) noexcept {
+        static constexpr unsigned __int128 max_pow10 = []() {
+            auto n = std::numeric_limits<uint64_t>::digits10;
+            unsigned __int128 d = 1;
+            for (int i = 0; i < n; ++i) {
+                d = d * 10;
+            }
+            return d;
+        }();
+
+        if (val <= std::numeric_limits<uint64_t>::max()) {
+            return std::to_chars(first, last, static_cast<uint64_t>(val));
         }
+
+        std::to_chars_result upper = to_chars(first, last, val / max_pow10);
+        if (upper.ec != std::errc{}) {
+            return upper;
+        }
+
+        first = upper.ptr;
+
+        std::to_chars_result lower = std::to_chars(first, last, static_cast<uint64_t>(val % max_pow10));
+        return lower;
+    }
+    inline std::to_chars_result to_chars(char *first, char *last, __int128 val) noexcept {
+        if (val >= 0) {
+            return to_chars(first, last, static_cast<unsigned __int128>(val));
+        }
+
+        if (val == std::numeric_limits<__int128>::min()) [[unlikely]] {
+            static constexpr std::string_view data = "-170141183460469231731687303715884105728";
+            static constexpr auto write = data;
+            if ((last - first) < static_cast<int64_t>(write.size())) {
+                return std::to_chars_result{.ptr = first, .ec = std::errc::value_too_large};
+            }
+            std::memcpy(first, write.data(), write.size());
+            return std::to_chars_result{.ptr = first + write.size(), .ec = std::errc{}};
+        }
+
+        if (first == last) [[unlikely]] {
+            return std::to_chars_result{.ptr = first, .ec = std::errc::value_too_large};
+        }
+
+        *first++ = '-';
+        return to_chars(first, last, static_cast<unsigned __int128>(-val));
+    }
+    inline bool to_chars_canonical(__int128 const value, writer::BufWriterParts const writer) noexcept {
         // +1 because of definition of digits10 https://en.cppreference.com/w/cpp/types/numeric_limits/digits10
         // +1 for sign
         static constexpr size_t buf_sz = std::numeric_limits<__int128>::digits10 + 1 + 1;
 
         std::array<char, buf_sz> buf;
+        std::to_chars_result const res = to_chars(buf.data(), buf.data() + buf.size(), value);
 
-        bool const neg = value < 0;
-        char *curr = buf.data() + buf.size();
-        while (value != 0) {
-            auto c = static_cast<int>(value % 10);
-            value = value / 10;
-            if (neg) {
-                c = -c;
-            }
-            --curr;
-            assert(curr >= buf.data());
-            *curr = static_cast<char>('0' + c);
-        }
-        if (neg) {
-            --curr;
-            assert(curr >= buf.data());
-            *curr = '-';
-        }
+        assert(res.ec == std::errc{});
 
-        return writer::write_str(std::string_view(curr, buf.data() + buf.size()), writer);
+        std::string_view const s{buf.data(), static_cast<std::string::size_type>(res.ptr - buf.data())};
+        return writer::write_str(s, writer);
     }
 #endif
 

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -12,12 +12,6 @@ namespace rdf4cpp::util {
     using Int128 = boost::multiprecision::checked_int128_t;
 #endif
 
-#ifdef RDF4CPP_USE_UNLIMITED_DATATYPES
-    using BigInt = boost::multiprecision::checked_cpp_int;
-#else
-    using BigInt = Int128;
-#endif
-
     // string -> int128 can be found in CharConvExt
 
 #ifdef __SIZEOF_INT128__

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -231,52 +231,47 @@ namespace rdf4cpp {
                 using t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::unsigned_magnitude, Checked, Alloc>>;
             };
             template<OverflowMode m, typename To, typename From>
-            requires (IntegralExt<To> || std::floating_point<To>) && (IntegralExt<From> || std::floating_point<From>)
+            requires(IntegralExt<To> || std::floating_point<To>) && (IntegralExt<From> || std::floating_point<From>)
             static constexpr bool cast_checked(From const &f, To &result) noexcept {
                 if constexpr (m == OverflowMode::Checked) {
                     if constexpr (std::floating_point<From> && !std::floating_point<To>) {
-                    // from https://stackoverflow.com/questions/25857843/how-do-i-convert-an-arbitrary-double-to-an-integer-while-avoiding-undefined-beha
-                    if (std::isnan(f) || std::isinf(f)) {
-                        return true;
-                    }
-                    if constexpr (!std::numeric_limits<To>::is_signed) {
-                        if (f < 0) {
+                        // from https://stackoverflow.com/questions/25857843/how-do-i-convert-an-arbitrary-double-to-an-integer-while-avoiding-undefined-beha
+                        if (std::isnan(f) || std::isinf(f)) {
+                            return true;
+                        }
+                        if constexpr (!std::numeric_limits<To>::is_signed) {
+                            if (f < 0) {
+                                return true;
+                            }
+                        }
+                        int exp;
+                        std::frexp(f, &exp);
+                        if (exp > std::numeric_limits<To>::digits && f != std::numeric_limits<To>::min()) {
+                            return true;
+                        }
+                    } else if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
+                        if (std::numeric_limits<To>::min() > f || f > std::numeric_limits<To>::max()) {
+                            return true;
+                        }
+                    } else if constexpr (std::numeric_limits<From>::is_signed) {
+                        if (f < 0 || static_cast<typename MakeUnsigned<From>::t>(f) > std::numeric_limits<To>::max()) {
+                            return true;
+                        }
+                    } else {
+                        if (f > std::numeric_limits<To>::max()) {
                             return true;
                         }
                     }
-                    int exp;
-                    std::frexp(f, &exp);
-                    if (exp > std::numeric_limits<To>::digits && f != std::numeric_limits<To>::min()) {
-                        return true;
-                    }
                 }
-                else if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
-                    if (std::numeric_limits<To>::min() > f || f > std::numeric_limits<To>::max()) {
-                        return true;
-                    }
-                }
-                else if constexpr (std::numeric_limits<From>::is_signed) {
-                    if (f < 0 || static_cast<typename MakeUnsigned<From>::t>(f) > std::numeric_limits<To>::max()) {
-                        return true;
-                    }
-                }
-                else {
-                    if (f > std::numeric_limits<To>::max()) {
-                        return true;
-                    }
-                }
+                result = static_cast<To>(f);
+                return false;
             }
-            result = static_cast<To>(f);
-            return false;
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
-        static constexpr bool cast_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &f, To &result) noexcept {
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename To>
+            static constexpr bool cast_checked(cpp_int_checked<MinBits, MaxBits, SignType, Alloc> const &f, To &result) noexcept {
                 if constexpr (m == OverflowMode::Checked) {
                     try {
                         result = static_cast<To>(f);
-                    } catch (std::overflow_error const &) {
-                        return true;
-                    } catch (std::range_error const &) {
+                    } catch (std::runtime_error const &) {
                         return true;
                     }
                     return false;
@@ -289,41 +284,39 @@ namespace rdf4cpp {
                 if constexpr (m == OverflowMode::Checked) {
                     try {
                         result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
-                    } catch (std::overflow_error const &) {
-                        return true;
-                    } catch (std::range_error const &) {
+                    } catch (std::runtime_error const &) {
                         return true;
                     }
                     return false;
                 }
                 result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
-            result = static_cast<To>(f);
-            return false;
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename From>
-        requires IntegralExt<From> || std::floating_point<From>
-        static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                try {
-                    result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
-                } catch (std::runtime_error const &) {
-                    return true;
-                }
                 return false;
             }
-            result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
-            return false;
-        }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename From>
-        requires IntegralExt<From> || std::floating_point<From>
-        static constexpr bool cast_checked(From const &f, cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
-            if constexpr (m == OverflowMode::Checked) {
-                try {
-                    result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
-                } catch (std::runtime_error const &) {
-                    return true;
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename From>
+            requires IntegralExt<From> || std::floating_point<From>
+            static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    try {
+                        result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
+                    } catch (std::runtime_error const &) {
+                        return true;
+                    }
+                    return false;
                 }
+                result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
                 return false;
+            }
+            template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename From>
+            requires IntegralExt<From> || std::floating_point<From>
+            static constexpr bool cast_checked(From const &f, cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
+                if constexpr (m == OverflowMode::Checked) {
+                    try {
+                        result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
+                    } catch (std::runtime_error const &) {
+                        return true;
+                    }
+                    return false;
+                }
             }
         }  // namespace detail
 

--- a/src/rdf4cpp/util/Int128.hpp
+++ b/src/rdf4cpp/util/Int128.hpp
@@ -305,12 +305,27 @@ namespace rdf4cpp::util {
         struct MakeUnsigned<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::signed_magnitude, Checked, Alloc>>> {
             using t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, boost::multiprecision::unsigned_magnitude, Checked, Alloc>>;
         };
-        // TODO check double->int64 conversion
         template<OverflowMode m, typename To, typename From>
         requires (IntegralExt<To> || std::floating_point<To>) && (IntegralExt<From> || std::floating_point<From>)
         static constexpr bool cast_checked(const From &f, To &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
-                if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
+                if constexpr (std::floating_point<From> && !std::floating_point<To>) {
+                    // from https://stackoverflow.com/questions/25857843/how-do-i-convert-an-arbitrary-double-to-an-integer-while-avoiding-undefined-beha
+                    if (std::isnan(f) || std::isinf(f)) {
+                        return true;
+                    }
+                    if constexpr (!std::numeric_limits<To>::is_signed) {
+                        if (f < 0) {
+                            return true;
+                        }
+                    }
+                    int exp;
+                    std::frexp(f, &exp);
+                    if (exp > std::numeric_limits<To>::digits && f != std::numeric_limits<To>::min()) {
+                        return true;
+                    }
+                }
+                else if constexpr (std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
                     if (std::numeric_limits<To>::min() > f || f > std::numeric_limits<To>::max()) {
                         return true;
                     }
@@ -359,14 +374,13 @@ namespace rdf4cpp::util {
             result = static_cast<To>(f);
             return false;
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename From>
+        requires IntegralExt<From> || std::floating_point<From>
         static constexpr bool cast_checked(From const &f, cpp_int_checked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
                 try {
                     result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f);
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
+                } catch (std::runtime_error const &) {
                     return true;
                 }
                 return false;
@@ -374,14 +388,13 @@ namespace rdf4cpp::util {
             result = static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(f));
             return false;
         }
-        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, IntegralExt From>
+        template<OverflowMode m, std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, typename Alloc, typename From>
+        requires IntegralExt<From> || std::floating_point<From>
         static constexpr bool cast_checked(From const &f, cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc> &result) noexcept {
             if constexpr (m == OverflowMode::Checked) {
                 try {
                     result = static_cast<cpp_int_unchecked<MinBits, MaxBits, SignType, Alloc>>(static_cast<cpp_int_checked<MinBits, MaxBits, SignType, Alloc>>(f));
-                } catch (std::overflow_error const &) {
-                    return true;
-                } catch (std::range_error const &) {
+                } catch (std::runtime_error const &) {
                     return true;
                 }
                 return false;

--- a/src/rdf4cpp/writer/BufWriter.hpp
+++ b/src/rdf4cpp/writer/BufWriter.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <rdf4cpp/Assert.hpp>
 
 namespace rdf4cpp::writer {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -275,6 +275,12 @@ target_link_libraries(bench_SerDe
         rdf4cpp
 )
 
+add_executable(bench_i128 bench_i128.cpp)
+target_link_libraries(bench_i128
+        nanobench::nanobench
+        rdf4cpp
+)
+
 add_executable(tests_RDFFileParser parser/tests_RDFFileParser.cpp)
 target_link_libraries(tests_RDFFileParser
         doctest::doctest

--- a/tests/bench_i128.cpp
+++ b/tests/bench_i128.cpp
@@ -1,0 +1,25 @@
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include <nanobench.h>
+#include <boost/multiprecision/cpp_int.hpp>
+
+int main() {
+    __int128 k = 100;
+    boost::multiprecision::checked_int128_t v = 1000;
+
+    ankerl::nanobench::Bench{}.relative(true)
+            .run("builtin", [&k]() {
+                for (int i=0;i<100;++i) {
+                    __builtin_mul_overflow(k, k, &k);
+                }
+            })
+            .run("boost", [&v]() {
+                for (int i=0;i<100;++i) {
+                    try {
+                        v = v * v;
+                    }
+                    catch (...) {}
+                }
+            });
+
+    std::cout << static_cast<int>(k) << v;
+}

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -214,7 +214,7 @@ TEST_CASE("decimal inlining sanity check") {
         }
 
         SUBCASE("exponent") {
-            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::util::Int128{5}, 1U << 10});
+            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::util::BigInt{5}, 1U << 10});
             CHECK(!l.is_inlined());
             CHECK(l.value<Decimal>() == Decimal::cpp_type(5, 1U << 10));
         }

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -182,7 +182,7 @@ TEST_CASE("decimal inlining sanity check") {
 
     SUBCASE("limits") {
         SUBCASE("unscaled value") {
-            auto const very_big_value = std::numeric_limits<rdf4cpp::util::Int128>::max();
+            auto const very_big_value = std::numeric_limits<rdf4cpp::Int128>::max();
             CHECK_GT(very_big_value, std::numeric_limits<int64_t>::max());
 
             // way over the limit
@@ -214,7 +214,7 @@ TEST_CASE("decimal inlining sanity check") {
         }
 
         SUBCASE("exponent") {
-            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::util::Int128{5}, 1U << 10});
+            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::Int128{5}, 1U << 10});
             CHECK(!l.is_inlined());
             CHECK(l.value<Decimal>() == Decimal::cpp_type(5, 1U << 10));
         }

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -185,7 +185,7 @@ TEST_CASE("decimal inlining sanity check") {
 
     SUBCASE("limits") {
         SUBCASE("unscaled value") {
-            boost::multiprecision::checked_int128_t const very_big_value = std::numeric_limits<boost::multiprecision::checked_int128_t>::max();
+            auto const very_big_value = std::numeric_limits<rdf4cpp::util::Int128>::max();
             CHECK_GT(very_big_value, std::numeric_limits<int64_t>::max());
 
             // way over the limit
@@ -217,7 +217,7 @@ TEST_CASE("decimal inlining sanity check") {
         }
 
         SUBCASE("exponent") {
-            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{boost::multiprecision::checked_int128_t{5}, 1U << 10});
+            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::util::Int128{5}, 1U << 10});
             CHECK(!l.is_inlined());
             CHECK(l.value<Decimal>() == Decimal::cpp_type(5, 1U << 10));
         }

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -185,7 +185,7 @@ TEST_CASE("decimal inlining sanity check") {
 
     SUBCASE("limits") {
         SUBCASE("unscaled value") {
-            boost::multiprecision::cpp_int const very_big_value{"99999999999999999999999999999999999999999999999"};
+            boost::multiprecision::checked_int128_t const very_big_value = std::numeric_limits<boost::multiprecision::checked_int128_t>::max();
             CHECK_GT(very_big_value, std::numeric_limits<int64_t>::max());
 
             // way over the limit
@@ -217,7 +217,7 @@ TEST_CASE("decimal inlining sanity check") {
         }
 
         SUBCASE("exponent") {
-            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{boost::multiprecision::cpp_int{5}, 1U << 10});
+            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{boost::multiprecision::checked_int128_t{5}, 1U << 10});
             CHECK(!l.is_inlined());
             CHECK(l.value<Decimal>() == Decimal::cpp_type(5, 1U << 10));
         }

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -66,10 +66,6 @@ TEST_CASE("Datatype Decimal") {
     CHECK(lit8.value<datatypes::xsd::Decimal>() == value);
     CHECK(lit8.lexical_form() == rdf_dbl_1_0);
 
-    value = type{std::numeric_limits<double>::max()};
-    auto lit9 = Literal::make_typed(to_string(value), type_iri);
-    CHECK(lit9.value<datatypes::xsd::Decimal>() == value);
-
     value = type{"3.111"};
     auto lit10 = Literal::make_typed_from_value<datatypes::xsd::Decimal>(value);
     CHECK(lit10.value<datatypes::xsd::Decimal>() == value);

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -18,6 +18,7 @@ TEST_CASE("decimal capabilities") {
 }
 
 TEST_CASE("Datatype Decimal") {
+    CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::Decimal::fixed_id));
 
     constexpr auto correct_type_iri_cstr = "http://www.w3.org/2001/XMLSchema#decimal";
 

--- a/tests/datatype/tests_Decimal.cpp
+++ b/tests/datatype/tests_Decimal.cpp
@@ -214,7 +214,7 @@ TEST_CASE("decimal inlining sanity check") {
         }
 
         SUBCASE("exponent") {
-            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::util::BigInt{5}, 1U << 10});
+            auto const l = Literal::make_typed_from_value<Decimal>(Decimal::cpp_type{rdf4cpp::util::Int128{5}, 1U << 10});
             CHECK(!l.is_inlined());
             CHECK(l.value<Decimal>() == Decimal::cpp_type(5, 1U << 10));
         }

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -15,6 +15,7 @@ TEST_CASE("integer capabilities") {
     static_assert(datatypes::xsd::Integer::subtype_rank == 1);
     static_assert(datatypes::ComparableLiteralDatatype<datatypes::xsd::Integer>);
     static_assert(datatypes::FixedIdLiteralDatatype<datatypes::xsd::Integer>);
+    static_assert(std::numeric_limits<datatypes::xsd::Integer::cpp_type>::digits10 > 16);
 }
 
 TEST_CASE("Datatype Integer") {

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Datatype Integer") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("a23dg", type_iri), "http://www.w3.org/2001/XMLSchema#integer parsing error: found a, invalid for datatype", InvalidNode);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("a23dg", type_iri), doctest::Contains("http://www.w3.org/2001/XMLSchema#integer parsing error: "), InvalidNode);
     CHECK_THROWS(no_discard_dummy = Literal::make_typed("2.2e-308", type_iri));
 }
 

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Datatype Integer") {
     // suppress warnings regarding attribute ‘nodiscard’
     Literal no_discard_dummy;
 
-    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("a23dg", type_iri), "http://www.w3.org/2001/XMLSchema#integer parsing error: Unexpected character encountered in input.", InvalidNode);
+    CHECK_THROWS_WITH_AS(no_discard_dummy = Literal::make_typed("a23dg", type_iri), "http://www.w3.org/2001/XMLSchema#integer parsing error: found a, invalid for datatype", InvalidNode);
     CHECK_THROWS(no_discard_dummy = Literal::make_typed("2.2e-308", type_iri));
 }
 
@@ -100,7 +100,7 @@ TEST_CASE("integer inlining") {
     }
 
     SUBCASE("too large") {
-        auto lit = Literal::make_typed_from_value<xsd::Integer>(xsd::Integer::cpp_type{"9999999999999999999999"});
+        auto lit = Literal::make_typed<xsd::Integer>("9999999999999999999999");
         CHECK(!lit.backend_handle().is_inlined());
     }
 }

--- a/tests/datatype/tests_Integer.cpp
+++ b/tests/datatype/tests_Integer.cpp
@@ -19,6 +19,7 @@ TEST_CASE("integer capabilities") {
 }
 
 TEST_CASE("Datatype Integer") {
+    CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::Integer::fixed_id));
 
     constexpr auto correct_type_iri_cstr = "http://www.w3.org/2001/XMLSchema#integer";
 

--- a/tests/datatype/tests_NegativeInteger.cpp
+++ b/tests/datatype/tests_NegativeInteger.cpp
@@ -6,6 +6,7 @@
 using namespace rdf4cpp;
 
 TEST_CASE("Datatype NegativeInteger") {
+    CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::NegativeInteger::fixed_id));
 
     constexpr auto correct_type_iri_cstr = "http://www.w3.org/2001/XMLSchema#negativeInteger";
 

--- a/tests/datatype/tests_NonNegativeInteger.cpp
+++ b/tests/datatype/tests_NonNegativeInteger.cpp
@@ -6,6 +6,7 @@
 using namespace rdf4cpp;
 
 TEST_CASE("Datatype NonNegativeInteger") {
+    CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::NonNegativeInteger::fixed_id));
 
     constexpr auto correct_type_iri_cstr = "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
 

--- a/tests/datatype/tests_NonPositiveInteger.cpp
+++ b/tests/datatype/tests_NonPositiveInteger.cpp
@@ -6,6 +6,7 @@
 using namespace rdf4cpp;
 
 TEST_CASE("Datatype NonPositiveInteger") {
+    CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::NonPositiveInteger::fixed_id));
 
     constexpr auto correct_type_iri_cstr = "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
 

--- a/tests/datatype/tests_NumOpResults.cpp
+++ b/tests/datatype/tests_NumOpResults.cpp
@@ -27,6 +27,7 @@ TEST_SUITE("numeric op results") {
             Decimal::cpp_type const zero{0};
             Decimal::cpp_type const one{1};
             Decimal::cpp_type const two{2};
+            Decimal::cpp_type const three{3};
             Decimal::cpp_type const min{std::numeric_limits<Decimal::cpp_type>::min()};
             Decimal::cpp_type const max{std::numeric_limits<Decimal::cpp_type>::max()};
             Decimal::cpp_type const big_number{"100000000000"};
@@ -34,8 +35,10 @@ TEST_SUITE("numeric op results") {
             // "If the number of digits in the mathematical result exceeds the number of digits
             // that the implementation retains for that operation, the result is truncated or rounded in an ·implementation-defined· manner."
             if (max != 0) {  // if max == 0 -> unlimited
-                CHECK(Decimal::add(max, one) == max);
-                CHECK(Decimal::sub(max, -one) == max);
+                auto r = Decimal::div(one, three);
+                CHECK(r.has_value());
+                CHECK(r.value() > zero);
+                CHECK(r.value() < one);
             }
 
             // "For xs:decimal operations, overflow behavior must raise a dynamic error [err:FOAR0002]."
@@ -48,10 +51,7 @@ TEST_SUITE("numeric op results") {
 
             // "On underflow, 0.0 must be returned."
             if (min != 0) {  // if min == 0 -> unlimited
-                CHECK(Decimal::sub(min, min) == zero);
-                CHECK(Decimal::div(min, two) == zero);
-                CHECK(Decimal::div(min, big_number) == zero);
-                CHECK(Decimal::mul(min, one / two) == zero);
+                CHECK(Decimal::div(one, max) == zero);
             }
 
             // https://www.w3.org/TR/xpath-functions/#func-numeric-divide

--- a/tests/datatype/tests_NumOpResults.cpp
+++ b/tests/datatype/tests_NumOpResults.cpp
@@ -26,7 +26,6 @@ TEST_SUITE("numeric op results") {
 
             Decimal::cpp_type const zero{0};
             Decimal::cpp_type const one{1};
-            Decimal::cpp_type const two{2};
             Decimal::cpp_type const three{3};
             Decimal::cpp_type const min{std::numeric_limits<Decimal::cpp_type>::min()};
             Decimal::cpp_type const max{std::numeric_limits<Decimal::cpp_type>::max()};

--- a/tests/datatype/tests_NumOpResults.cpp
+++ b/tests/datatype/tests_NumOpResults.cpp
@@ -49,6 +49,12 @@ TEST_SUITE("numeric op results") {
             }
 
             // "On underflow, 0.0 must be returned."
+            /*
+             * XPath (and by extension SPARQL) do not define underflow themselves.
+             * But from how they use it, (see https://www.w3.org/TR/xpath-functions/#op.numeric ) it seems, they understand it the same as it is used in IEEE floats.
+             * And for these ( https://ieeemilestones.ethw.org/w/images/5/54/Handbook_Floating_Point_Chapter_3.pdf page 31)
+             * underflow occurs if the absolute of the result is not 0 but smaller than the smallest representable value.
+             */
             if (min != 0) {  // if min == 0 -> unlimited
                 CHECK(Decimal::div(one, max) == zero);
             }

--- a/tests/datatype/tests_PositiveInteger.cpp
+++ b/tests/datatype/tests_PositiveInteger.cpp
@@ -6,6 +6,7 @@
 using namespace rdf4cpp;
 
 TEST_CASE("Datatype PositiveInteger") {
+    CHECK(storage::default_node_storage.has_specialized_storage_for(datatypes::xsd::PositiveInteger::fixed_id));
 
     constexpr auto correct_type_iri_cstr = "http://www.w3.org/2001/XMLSchema#positiveInteger";
 

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -176,7 +176,7 @@ TEST_CASE("precision") {
     CHECK(ys > std::chrono::years{10000});
     CHECK(ys > std::chrono::years{static_cast<int>(std::chrono::year::max())});
 
-    using I = rdf4cpp::util::Int128;
+    using I = rdf4cpp::Int128;
     using CI = rdf4cpp::util::CheckedIntegral<I>;
     CI end_of_universe = rdf4cpp::datatypes::registry::util::from_chars<I, "p">("100000000000000");
     CHECK(end_of_universe < std::numeric_limits<int64_t>::max());

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -453,6 +453,9 @@ TEST_CASE("datatype dateTime") {
 
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("-13798000000-01-01T00:00:00Z").lexical_form() == "-13798000000-01-01T00:00:00Z"); // check that age of universe is in range
     CHECK(Literal::make_typed<datatypes::xsd::DateTime>("100000000000000-01-01T00:00:00Z").lexical_form() == "100000000000000-01-01T00:00:00Z");
+
+    auto too_big = Literal::make_typed_from_value<datatypes::xsd::DateTime>(datatypes::xsd::DateTime::cpp_type{TimePoint::max(), Timezone{}});
+    CHECK(too_big.lexical_form() == "invalid DateTime");
 }
 
 TEST_CASE("datatype dateTimeStamp") {
@@ -509,6 +512,9 @@ TEST_CASE("datatype dateTimeStamp") {
     CHECK(a.null());  // turn off unused and nodiscard ignored warnings
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-05-06T00:00:00.000Z") == Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-05-05T24:00:00Z"));
     CHECK(Literal::make_typed<datatypes::xsd::DateTimeStamp>("2042-05-05T24:00:00.000Z").lexical_form() == "2042-05-06T00:00:00Z");
+
+    auto too_big = Literal::make_typed_from_value<datatypes::xsd::DateTimeStamp>(datatypes::xsd::DateTimeStamp::cpp_type{Timezone{}, TimePoint::max()});
+    CHECK(too_big.lexical_form() == "invalid DateTimeStamp");
 }
 
 TEST_CASE("datatype duration") {
@@ -679,6 +685,15 @@ TEST_CASE("Literal API") {
     CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3+1:30").as_tz() == Literal::make_simple("+01:30"));
     CHECK(Literal::make_typed<datatypes::xsd::GDay>("---3").as_tz() == Literal::make_simple(""));
     CHECK(Literal::make_simple("5").as_tz().null());
+
+    auto too_big = Literal::make_typed_from_value<datatypes::xsd::DateTime>(datatypes::xsd::DateTime::cpp_type{TimePoint::max(), Timezone{}});
+    CHECK(!too_big.year().has_value());
+    CHECK(!too_big.month().has_value());
+    CHECK(!too_big.day().has_value());
+    CHECK(!too_big.hours().has_value());
+    CHECK(!too_big.minutes().has_value());
+    CHECK(!too_big.seconds().has_value());
+    CHECK(too_big.timezone().has_value());
 }
 
 TEST_CASE("arithmetic") {

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -187,6 +187,9 @@ TEST_CASE("precision") {
     CHECK(nanos.count() > end_of_universe);
     auto r = CI(std::numeric_limits<I>::max()) / nanos.count();
     CHECK(r > 0);
+
+    CHECK(!rdf4cpp::util::deconstruct_timepoint(rdf4cpp::TimePoint::max()).has_value());
+    CHECK(!rdf4cpp::util::deconstruct_timepoint(rdf4cpp::TimePoint::min()).has_value());
 }
 
 TEST_CASE("datatype gYear") {
@@ -394,13 +397,13 @@ TEST_CASE("datatype dateTime") {
     CHECK(std::string(datatypes::xsd::DateTime::identifier) == "http://www.w3.org/2001/XMLSchema#dateTime");
 
     rdf4cpp::OptionalTimezone const tz = std::nullopt;
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), tz), "2042-05-01T00:50:00", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789}), tz), "2042-05-01T12:34:56.789", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100}), tz), "2042-05-01T00:50:00.1", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789}), tz), "2042-05-01T00:50:00.12345678910", std::partial_ordering::equivalent, true);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42}), tz), "2042-05-01T00:50:00", std::partial_ordering::less);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::hours{1}}), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::minutes{-65}}), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), tz), "2042-05-01T00:50:00", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789}), tz), "2042-05-01T12:34:56.789", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100}), tz), "2042-05-01T00:50:00.1", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789}), tz), "2042-05-01T00:50:00.12345678910", std::partial_ordering::equivalent, true);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42}), tz), "2042-05-01T00:50:00", std::partial_ordering::less);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::hours{1}}), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::minutes{-65}}), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTime>("2042-05-05T13:40:08", "2042-05-05T13:40:08", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTime>("2041-05-05T13:40:08", "2042-05-05T13:40:08", std::partial_ordering::less);
     basic_test<datatypes::xsd::DateTime>("2042-05-05T13:40:08", "2041-05-05T13:40:08", std::partial_ordering::greater);
@@ -458,13 +461,13 @@ TEST_CASE("datatype dateTimeStamp") {
     CHECK(std::string(datatypes::xsd::DateTimeStamp::identifier) == "http://www.w3.org/2001/XMLSchema#dateTimeStamp");
 
     Timezone const tz{std::chrono::hours{0}};
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00Z", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789})), "2042-05-01T12:34:56.789Z", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100})), "2042-05-01T00:50:00.1Z", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789})), "2042-05-01T00:50:00.12345678910Z", std::partial_ordering::equivalent, true);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42})), "2042-05-01T00:50:00Z", std::partial_ordering::less);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::hours{1}}, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::minutes{-65}}, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00Z", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789})), "2042-05-01T12:34:56.789Z", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100})), "2042-05-01T00:50:00.1Z", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789})), "2042-05-01T00:50:00.12345678910Z", std::partial_ordering::equivalent, true);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42})), "2042-05-01T00:50:00Z", std::partial_ordering::less);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::hours{1}}, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::minutes{-65}}, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTimeStamp>("2042-05-05T13:40:08Z", "2042-05-05T13:40:08Z", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTimeStamp>("2041-05-05T13:40:08Z", "2042-05-05T13:40:08Z", std::partial_ordering::less);
     basic_test<datatypes::xsd::DateTimeStamp>("2042-05-05T13:40:08Z", "2041-05-05T13:40:08Z", std::partial_ordering::greater);

--- a/tests/datatype/tests_time_types.cpp
+++ b/tests/datatype/tests_time_types.cpp
@@ -176,12 +176,17 @@ TEST_CASE("precision") {
     CHECK(ys > std::chrono::years{10000});
     CHECK(ys > std::chrono::years{static_cast<int>(std::chrono::year::max())});
 
-    rdf4cpp::DurationNano::rep end_of_universe{"100000000000000"};
+    using I = rdf4cpp::util::Int128;
+    using CI = rdf4cpp::util::CheckedIntegral<I>;
+    CI end_of_universe = rdf4cpp::datatypes::registry::util::from_chars<I, "p">("100000000000000");
     CHECK(end_of_universe < std::numeric_limits<int64_t>::max());
-    using checked_years = std::chrono::duration<rdf4cpp::DurationNano::rep, std::chrono::years::period>;
-    using checked_nanos = std::chrono::duration<rdf4cpp::DurationNano::rep, std::chrono::nanoseconds::period>;
-    auto nanos = static_cast<checked_nanos>(checked_years{end_of_universe});  // throws, if out of range
+    using checked_years = std::chrono::duration<CI, std::chrono::years::period>;
+    using checked_nanos = std::chrono::duration<CI, std::chrono::nanoseconds::period>;
+    auto nanos = static_cast<checked_nanos>(checked_years{end_of_universe});
+    CHECK(!nanos.count().is_invalid());
     CHECK(nanos.count() > end_of_universe);
+    auto r = CI(std::numeric_limits<I>::max()) / nanos.count();
+    CHECK(r > 0);
 }
 
 TEST_CASE("datatype gYear") {
@@ -389,13 +394,13 @@ TEST_CASE("datatype dateTime") {
     CHECK(std::string(datatypes::xsd::DateTime::identifier) == "http://www.w3.org/2001/XMLSchema#dateTime");
 
     rdf4cpp::OptionalTimezone const tz = std::nullopt;
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), tz), "2042-05-01T00:50:00", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789}), tz), "2042-05-01T12:34:56.789", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100}), tz), "2042-05-01T00:50:00.1", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789}), tz), "2042-05-01T00:50:00.12345678910", std::partial_ordering::equivalent, true);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42}), tz), "2042-05-01T00:50:00", std::partial_ordering::less);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::hours{1}}), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTime>(std::make_pair(rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::minutes{-65}}), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), tz), "2042-05-01T00:50:00", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789}), tz), "2042-05-01T12:34:56.789", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100}), tz), "2042-05-01T00:50:00.1", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789}), tz), "2042-05-01T00:50:00.12345678910", std::partial_ordering::equivalent, true);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42}), tz), "2042-05-01T00:50:00", std::partial_ordering::less);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::hours{1}}), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTime>(std::make_pair(*rdf4cpp::util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50}), Timezone{std::chrono::minutes{-65}}), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTime>("2042-05-05T13:40:08", "2042-05-05T13:40:08", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTime>("2041-05-05T13:40:08", "2042-05-05T13:40:08", std::partial_ordering::less);
     basic_test<datatypes::xsd::DateTime>("2042-05-05T13:40:08", "2041-05-05T13:40:08", std::partial_ordering::greater);
@@ -453,13 +458,13 @@ TEST_CASE("datatype dateTimeStamp") {
     CHECK(std::string(datatypes::xsd::DateTimeStamp::identifier) == "http://www.w3.org/2001/XMLSchema#dateTimeStamp");
 
     Timezone const tz{std::chrono::hours{0}};
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00Z", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789})), "2042-05-01T12:34:56.789Z", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100})), "2042-05-01T00:50:00.1Z", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789})), "2042-05-01T00:50:00.12345678910Z", std::partial_ordering::equivalent, true);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42})), "2042-05-01T00:50:00Z", std::partial_ordering::less);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::hours{1}}, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
-    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::minutes{-65}}, util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00Z", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::hours{12} + std::chrono::minutes{34} + std::chrono::seconds{56} + std::chrono::milliseconds{789})), "2042-05-01T12:34:56.789Z", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::milliseconds{100})), "2042-05-01T00:50:00.1Z", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50} + std::chrono::nanoseconds{123456789})), "2042-05-01T00:50:00.12345678910Z", std::partial_ordering::equivalent, true);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(tz, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{42})), "2042-05-01T00:50:00Z", std::partial_ordering::less);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::hours{1}}, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00+01:00", std::partial_ordering::equivalent);
+    basic_test<datatypes::xsd::DateTimeStamp>(ZonedTime(Timezone{std::chrono::minutes{-65}}, *util::construct_timepoint(YearMonthDay{Year{2042}, std::chrono::month{5}, std::chrono::day{1}}, std::chrono::minutes{50})), "2042-05-01T00:50:00-01:05", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTimeStamp>("2042-05-05T13:40:08Z", "2042-05-05T13:40:08Z", std::partial_ordering::equivalent);
     basic_test<datatypes::xsd::DateTimeStamp>("2041-05-05T13:40:08Z", "2042-05-05T13:40:08Z", std::partial_ordering::less);
     basic_test<datatypes::xsd::DateTimeStamp>("2042-05-05T13:40:08Z", "2041-05-05T13:40:08Z", std::partial_ordering::greater);

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -213,7 +213,7 @@ TEST_CASE("Literal - casting") {
             }
 
             SUBCASE("non-integral") {
-                auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.5));
+                auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.5));
                 auto const lit2 = lit1.template cast<String>();
 
                 CHECK_EQ(lit2.template value<String>(), "1.5");
@@ -326,7 +326,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("dec -> flt") {
-        auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0));
+        auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0));
         auto const lit2 = lit1.template cast<Float>();
 
         CHECK_EQ(lit2.datatype(), IRI{Float::identifier});
@@ -334,7 +334,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("dec -> dbl") {
-        auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0));
+        auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0));
         auto const lit2 = lit1.template cast<Double>();
 
         CHECK_EQ(lit2.datatype(), IRI{Double::identifier});
@@ -342,7 +342,7 @@ TEST_CASE("Literal - casting") {
     }
 
     SUBCASE("dec -> int") {
-        auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.2));
+        auto const lit1 = Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.2));
         auto const lit2 = lit1.template cast<Int>();
 
         CHECK_EQ(lit2.datatype(), IRI{Int::identifier});

--- a/tests/nodes/tests_Literal_ops.cpp
+++ b/tests/nodes/tests_Literal_ops.cpp
@@ -160,8 +160,8 @@ TEST_CASE("Literal - logical ops") {
 
 TEST_CASE("Literal - numeric ops") {
     // simple promotion test cases
-    GENERATE_BINOP_TESTCASE(Float, 42.f, +, Decimal, rdf4cpp::BigDecimal{120.0}, Float, 162.f);
-    GENERATE_BINOP_TESTCASE(Decimal, rdf4cpp::BigDecimal{2.f}, *, Float, 120.0, Float, 240.f);
+    GENERATE_BINOP_TESTCASE(Float, 42.f, +, Decimal, rdf4cpp::Decimal128{120.0}, Float, 162.f);
+    GENERATE_BINOP_TESTCASE(Decimal, rdf4cpp::Decimal128{2.f}, *, Float, 120.0, Float, 240.f);
     GENERATE_BINOP_TESTCASE(Integer, 100, -, Float, 1.f, Float, 99.f);
     GENERATE_BINOP_TESTCASE(Float, 100.f, /, Integer, 2, Float, 50.f);
 
@@ -173,9 +173,9 @@ TEST_CASE("Literal - numeric ops") {
     GENERATE_BINOP_TESTCASE(Integer, 1, +, Integer , 2, Integer, 3);
     GENERATE_BINOP_TESTCASE(Integer, 12, -, Integer, 1, Integer, 11);
     GENERATE_BINOP_TESTCASE(Integer, 3, *, Integer, 6, Integer, 18);
-    GENERATE_BINOP_TESTCASE(Integer, 12, /, Integer, 4, Decimal, rdf4cpp::BigDecimal{3.0});
+    GENERATE_BINOP_TESTCASE(Integer, 12, /, Integer, 4, Decimal, rdf4cpp::Decimal128{3.0});
     GENERATE_BINOP_TESTCASE(Int, 1, +, Integer, 3, Integer, 4);
-    GENERATE_BINOP_TESTCASE(Int, 1, +, Decimal, rdf4cpp::BigDecimal{2}, Decimal, rdf4cpp::BigDecimal{3});
+    GENERATE_BINOP_TESTCASE(Int, 1, +, Decimal, rdf4cpp::Decimal128{2}, Decimal, rdf4cpp::Decimal128{3});
     GENERATE_UNOP_TESTCASE(Integer, 1, +, Integer, 1);
     GENERATE_UNOP_TESTCASE(Integer, 1, -, Integer, -1);
 

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -82,7 +82,7 @@ TEST_SUITE("comparisons") {
         SUBCASE("nulls") {
             CHECK(Literal{} <=> Literal{} == std::partial_ordering::unordered);
             CHECK(Literal{} <=> Literal::make_typed_from_value<Int>(1) == std::partial_ordering::unordered);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)) <=> Literal{} == std::partial_ordering::unordered);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0)) <=> Literal{} == std::partial_ordering::unordered);
         }
 
         SUBCASE("inconvertibility") {
@@ -100,7 +100,7 @@ TEST_SUITE("comparisons") {
         SUBCASE("conversion") {
             CHECK(Literal::make_typed_from_value<Int>(1) <=> Literal::make_typed_from_value<Integer>(10) == std::partial_ordering::less);
             CHECK(Literal::make_typed_from_value<Integer>(0) <=> Literal::make_typed_from_value<Float>(1.2f) == std::partial_ordering::less);
-            CHECK(Literal::make_typed_from_value<Float>(1.f) <=> Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)) == std::partial_ordering::equivalent);
+            CHECK(Literal::make_typed_from_value<Float>(1.f) <=> Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0)) == std::partial_ordering::equivalent);
         }
     }
 
@@ -113,7 +113,7 @@ TEST_SUITE("comparisons") {
             CHECK(Literal::make_typed_from_value<Float>(10.f).order(Literal::make_typed_from_value<Incomparable>(1)) == std::weak_ordering::less);
 
             // reason: decimal has fixed id and any fixed id type is always less than a dynamic one
-            CHECK(Literal::make_typed_from_value<Incomparable>(1).order(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(10.0))) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Incomparable>(1).order(Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(10.0))) == std::weak_ordering::greater);
         }
 
         SUBCASE("nulls") {
@@ -127,10 +127,10 @@ TEST_SUITE("comparisons") {
         SUBCASE("test type ordering extensions") {
             // expected: string < float < decimal < integer < int
 
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<Float>(1)) == std::weak_ordering::greater);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);
-            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::BigDecimal(1.0)).order(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0)).order(Literal::make_typed_from_value<Float>(1)) == std::weak_ordering::greater);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0)).order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0)).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);
+            CHECK(Literal::make_typed_from_value<Decimal>(rdf4cpp::Decimal128(1.0)).order(Literal::make_typed_from_value<String>("hello")) == std::weak_ordering::greater);
 
             CHECK(Literal::make_typed_from_value<Float>(1.f).order(Literal::make_typed_from_value<Int>(1)) == std::weak_ordering::less);
             CHECK(Literal::make_typed_from_value<Float>(1.f).order(Literal::make_typed_from_value<Integer>(1)) == std::weak_ordering::less);

--- a/tests/serializer/tests_Serialize.cpp
+++ b/tests/serializer/tests_Serialize.cpp
@@ -62,7 +62,7 @@ TEST_SUITE("Serialize") {
             run_ser_test(lit, "\"simple\"");
         }
         SUBCASE("non-inlined xsd:integer") {
-            auto lit = Literal::make_typed_from_value<xsd::Integer>(xsd::Integer::cpp_type{"87960930222089"});
+            auto lit = Literal::make_typed<xsd::Integer>("87960930222089");
             run_ser_test(lit, "\"87960930222089\"^^<http://www.w3.org/2001/XMLSchema#integer>");
         }
         SUBCASE("inlined xsd:int") {

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -5,9 +5,9 @@
 #include <rdf4cpp/datatypes/registry/util/ConstexprString.hpp>
 #include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
-using Dec = rdf4cpp::BigDecimal<>;
-using DecI = rdf4cpp::BigDecimal<int32_t, uint32_t>;
-using RoundingMode = rdf4cpp::RoundingMode;
+using Dec = rdf4cpp::Decimal128;
+using DecI = rdf4cpp::util::BigDecimal<int32_t, uint32_t>;
+using RoundingMode = rdf4cpp::util::RoundingMode;
 
 #ifdef __SIZEOF_INT128__
 namespace doctest {
@@ -189,9 +189,9 @@ TEST_CASE("int128 from_chars") {
 
 TEST_CASE("basics") {
     SUBCASE("ctor and compare") {
-        static_assert(rdf4cpp::BigDecimalBaseType<uint32_t>);
-        static_assert(rdf4cpp::BigDecimalBaseType<int32_t>);
-        static_assert(rdf4cpp::BigDecimalBaseType<boost::multiprecision::cpp_int>);
+        static_assert(rdf4cpp::util::BigDecimalBaseType<uint32_t>);
+        static_assert(rdf4cpp::util::BigDecimalBaseType<int32_t>);
+        static_assert(rdf4cpp::util::BigDecimalBaseType<boost::multiprecision::cpp_int>);
         Dec d{500, 1};
         CHECK_GT(d, Dec{-500, 1});
         CHECK(Dec{-500, 1} < d);
@@ -385,7 +385,7 @@ TEST_CASE("conversion") {
         str << Dec{50, 1};
         CHECK_EQ(str.view(), "5.0");
         // uses string conversion, so no more tests here
-        str << rdf4cpp::util::Int128{100};
+        str << rdf4cpp::Int128{100};
         CHECK_EQ(str.view(), "5.0100");
     }
     SUBCASE("from double") {
@@ -430,14 +430,14 @@ TEST_CASE("conversion") {
         // no e notation allowed by rdf (xml) standard
     }
     SUBCASE("from Int128") {
-        CHECK(Dec{rdf4cpp::util::Int128{5}} == Dec{5, 0});
+        CHECK(Dec{rdf4cpp::Int128{5}} == Dec{5, 0});
     }
     SUBCASE("to Int128") {
-        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{5, 0}) == rdf4cpp::util::Int128{5});
-        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{59, 1}) == rdf4cpp::util::Int128{5});
-        if constexpr (std::numeric_limits<rdf4cpp::util::Int128>::is_bounded) {
-            CHECK(static_cast<rdf4cpp::util::Int128>(Dec{std::numeric_limits<rdf4cpp::util::Int128>::max(), std::numeric_limits<rdf4cpp::util::Int128>::digits10}) ==
-                  (std::same_as<rdf4cpp::util::Int128, boost::multiprecision::checked_int128_t> ? rdf4cpp::util::Int128{3} : rdf4cpp::util::Int128{1})
+        CHECK(static_cast<rdf4cpp::Int128>(Dec{5, 0}) == rdf4cpp::Int128{5});
+        CHECK(static_cast<rdf4cpp::Int128>(Dec{59, 1}) == rdf4cpp::Int128{5});
+        if constexpr (std::numeric_limits<rdf4cpp::Int128>::is_bounded) {
+            CHECK(static_cast<rdf4cpp::Int128>(Dec{std::numeric_limits<rdf4cpp::Int128>::max(), std::numeric_limits<rdf4cpp::Int128>::digits10}) ==
+                  (std::same_as<rdf4cpp::Int128, boost::multiprecision::checked_int128_t> ? rdf4cpp::Int128{3} : rdf4cpp::Int128{1})
             );
         }
     }

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -2,6 +2,8 @@
 #include <doctest/doctest.h>
 
 #include <rdf4cpp/BigDecimal.hpp>
+#include <rdf4cpp/datatypes/registry/util/ConstexprString.hpp>
+#include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
 
 using Dec = rdf4cpp::BigDecimal<>;
 using DecI = rdf4cpp::BigDecimal<int32_t, uint32_t>;
@@ -175,6 +177,14 @@ TEST_CASE("int128 to_chars") {
     CHECK(tos(std::numeric_limits<__int128>::max()) == "170141183460469231731687303715884105727");
     CHECK(tos(std::numeric_limits<__int128>::min()) == "-170141183460469231731687303715884105728");
     CHECK(tos(std::numeric_limits<__int128>::min()+1) == "-170141183460469231731687303715884105727");
+}
+
+TEST_CASE("int128 from_chars") {
+    static constexpr rdf4cpp::datatypes::registry::util::ConstexprString s{"test"};
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("0") == 0);
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("170141183460469231731687303715884105727") == std::numeric_limits<__int128>::max());
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-170141183460469231731687303715884105728") == std::numeric_limits<__int128>::min());
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-170141183460469231731687303715884105727") == std::numeric_limits<__int128>::min()+1);
 }
 
 TEST_CASE("basics") {

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -131,6 +131,36 @@ TEST_CASE_TEMPLATE("checked arithmetic unsigned", T, uint32_t, uint64_t, unsigne
         CHECK(pow_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), 2, re) == true);
     }
 }
+TEST_CASE_TEMPLATE("checked casting", T, uint32_t, uint64_t, unsigned __int128, boost::multiprecision::checked_uint256_t,
+                   int32_t, int64_t, __int128, boost::multiprecision::checked_int256_t ) {
+    using namespace rdf4cpp::util::detail;
+
+    static constexpr bool sign = std::numeric_limits<T>::is_signed;
+    [[maybe_unused]] uint8_t u8 = 0;
+    [[maybe_unused]] int8_t i8 = 0;
+    [[maybe_unused]] T t{};
+    CHECK(cast_checked<OverflowMode::Checked>(T{5}, i8) == false);
+    CHECK(i8 == 5);
+    CHECK(cast_checked<OverflowMode::Checked>(T{5}, u8) == false);
+    CHECK(u8 == 5);
+    if constexpr (sign) {
+        CHECK(cast_checked<OverflowMode::Checked>(T{-5}, i8) == false);
+        CHECK(i8 == -5);
+        CHECK(cast_checked<OverflowMode::Checked>(T{-5}, u8) == true);
+        CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<T>::min(), i8) == true);
+        if constexpr (IntegralExt<T>) {
+            CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<typename MakeUnsigned<T>::t>::max(), t) == true);
+        }
+        else {
+            CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<typename MakeUnsigned<T>::t>::max(), t) == false);
+            CHECK(t == std::numeric_limits<T>::max());
+        }
+    }
+    CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), u8) == true);
+    CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), i8) == true);
+    CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<uint8_t>::max(), t) == false);
+    CHECK(t == std::numeric_limits<uint8_t>::max());
+}
 
 TEST_CASE("basics") {
     SUBCASE("ctor and compare") {

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -165,6 +165,18 @@ TEST_CASE_TEMPLATE("checked casting", T, uint32_t, uint64_t, unsigned __int128, 
     CHECK(t == std::numeric_limits<uint8_t>::max());
 }
 
+TEST_CASE("int128 to_chars") {
+    auto tos = [](__int128 x) {
+        return rdf4cpp::writer::StringWriter::oneshot([x](rdf4cpp::writer::StringWriter& w) {
+            return rdf4cpp::util::to_chars_canonical(x, w);
+        });
+    };
+    CHECK(tos(0) == "0");
+    CHECK(tos(std::numeric_limits<__int128>::max()) == "170141183460469231731687303715884105727");
+    CHECK(tos(std::numeric_limits<__int128>::min()) == "-170141183460469231731687303715884105728");
+    CHECK(tos(std::numeric_limits<__int128>::min()+1) == "-170141183460469231731687303715884105727");
+}
+
 TEST_CASE("basics") {
     SUBCASE("ctor and compare") {
         static_assert(rdf4cpp::BigDecimalBaseType<uint32_t>);
@@ -363,7 +375,7 @@ TEST_CASE("conversion") {
         str << Dec{50, 1};
         CHECK_EQ(str.view(), "5.0");
         // uses string conversion, so no more tests here
-        str << rdf4cpp::util::BigInt{100};
+        str << rdf4cpp::util::Int128{100};
         CHECK_EQ(str.view(), "5.0100");
     }
     SUBCASE("from double") {
@@ -374,12 +386,7 @@ TEST_CASE("conversion") {
         CHECK(Dec{1.0} == Dec{1, 0});
         CHECK(Dec{1.2} != Dec{12, 1}); // 1.2 can not be exactly represented as double but can be as decimal
         CHECK_EQ(static_cast<float>(Dec{1.0}), 1.0f);
-        if constexpr (std::same_as<rdf4cpp::util::BigInt, rdf4cpp::util::Int128>) {
-            CHECK_THROWS_AS([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()), std::overflow_error);
-        }
-        else {
-            CHECK_NOTHROW([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()));
-        }
+        CHECK_THROWS_AS([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()), std::overflow_error);
         CHECK(Dec(std::numeric_limits<double>::min()) > Dec(0, 0));
         CHECK(Dec(std::numeric_limits<double>::denorm_min()) > Dec(0, 0));
     }
@@ -413,14 +420,14 @@ TEST_CASE("conversion") {
         // no e notation allowed by rdf (xml) standard
     }
     SUBCASE("from Int128") {
-        CHECK(Dec{rdf4cpp::util::BigInt{5}} == Dec{5, 0});
+        CHECK(Dec{rdf4cpp::util::Int128{5}} == Dec{5, 0});
     }
     SUBCASE("to Int128") {
-        CHECK(static_cast<rdf4cpp::util::BigInt>(Dec{5, 0}) == rdf4cpp::util::BigInt{5});
-        CHECK(static_cast<rdf4cpp::util::BigInt>(Dec{59, 1}) == rdf4cpp::util::BigInt{5});
-        if constexpr (std::numeric_limits<rdf4cpp::util::BigInt>::is_bounded) {
-            CHECK(static_cast<rdf4cpp::util::BigInt>(Dec{std::numeric_limits<rdf4cpp::util::BigInt>::max(), std::numeric_limits<rdf4cpp::util::BigInt>::digits10}) ==
-                  (std::same_as<rdf4cpp::util::BigInt, boost::multiprecision::checked_int128_t> ? rdf4cpp::util::BigInt{3} : rdf4cpp::util::BigInt{1})
+        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{5, 0}) == rdf4cpp::util::Int128{5});
+        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{59, 1}) == rdf4cpp::util::Int128{5});
+        if constexpr (std::numeric_limits<rdf4cpp::util::Int128>::is_bounded) {
+            CHECK(static_cast<rdf4cpp::util::Int128>(Dec{std::numeric_limits<rdf4cpp::util::Int128>::max(), std::numeric_limits<rdf4cpp::util::Int128>::digits10}) ==
+                  (std::same_as<rdf4cpp::util::Int128, boost::multiprecision::checked_int128_t> ? rdf4cpp::util::Int128{3} : rdf4cpp::util::Int128{1})
             );
         }
     }

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -1,6 +1,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
+#include <random>
+
 #include <rdf4cpp/BigDecimal.hpp>
 #include <rdf4cpp/datatypes/registry/util/ConstexprString.hpp>
 #include <rdf4cpp/datatypes/registry/util/CharConvExt.hpp>
@@ -167,6 +169,17 @@ TEST_CASE_TEMPLATE("checked casting", T, uint32_t, uint64_t, unsigned __int128, 
     CHECK(t == std::numeric_limits<uint8_t>::max());
 }
 
+constexpr __int128 Make128(int64_t h, int64_t l) {
+    constexpr __int128 p = []() {
+        __int128 r = 1;
+        for (int i = 0; i < std::numeric_limits<int64_t>::digits10; ++i) {
+            r *= 10;
+        }
+        return r;
+    }();
+    return static_cast<__int128>(h) * p + l;
+}
+
 TEST_CASE("int128 to_chars") {
     auto tos = [](__int128 x) {
         return rdf4cpp::writer::StringWriter::oneshot([x](rdf4cpp::writer::StringWriter& w) {
@@ -177,6 +190,15 @@ TEST_CASE("int128 to_chars") {
     CHECK(tos(std::numeric_limits<__int128>::max()) == "170141183460469231731687303715884105727");
     CHECK(tos(std::numeric_limits<__int128>::min()) == "-170141183460469231731687303715884105728");
     CHECK(tos(std::numeric_limits<__int128>::min()+1) == "-170141183460469231731687303715884105727");
+    CHECK(Make128(5000, 5) > std::numeric_limits<uint64_t>::max());
+    CHECK(tos(Make128(1, 5)) == "1000000000000000005");
+    CHECK(tos(Make128(5001, 5)) == "5001000000000000000005");
+    CHECK(tos(Make128(5000, 5)) == "5000000000000000000005");
+    CHECK(tos(Make128(5000, 500000)) == "5000000000000000500000");
+    CHECK(tos(Make128(-1, -5)) == "-1000000000000000005");
+    CHECK(tos(Make128(-5001, -5)) == "-5001000000000000000005");
+    CHECK(tos(Make128(-5000, -5)) == "-5000000000000000000005");
+    CHECK(tos(Make128(-5000, -500000)) == "-5000000000000000500000");
 }
 
 TEST_CASE("int128 from_chars") {
@@ -185,6 +207,28 @@ TEST_CASE("int128 from_chars") {
     CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("170141183460469231731687303715884105727") == std::numeric_limits<__int128>::max());
     CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-170141183460469231731687303715884105728") == std::numeric_limits<__int128>::min());
     CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-170141183460469231731687303715884105727") == std::numeric_limits<__int128>::min()+1);
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("1000000000000000005") == Make128(1, 5));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("5000000000000000000005") == Make128(5000, 5));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("5001000000000000000005") == Make128(5001, 5));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("5000000000000000500000") == Make128(5000, 500000));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-5001000000000000000005") == Make128(-5001, -5));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-5000000000000000000005") == Make128(-5000, -5));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-1000000000000000005") == Make128(-1, -5));
+    CHECK(rdf4cpp::datatypes::registry::util::from_chars<__int128, s>("-5000000000000000500000") == Make128(-5000, -500000));
+
+    std::random_device rd{};
+    std::default_random_engine r{std::uniform_int_distribution<size_t>{}(rd)};
+    std::uniform_int_distribution<int64_t> d{};
+    std::array<char, std::numeric_limits<__int128>::digits10 + 2> buff;
+    for (int i = 0; i < 100000; ++i) {
+        __int128 const c = static_cast<__int128>(d(r)) << 64 | d(r);
+        auto char_res = rdf4cpp::util::to_chars(buff.data(), buff.data() + buff.size(), c);
+        CHECK(char_res.ec == std::errc{});
+        auto len = char_res.ptr - buff.data();
+        CHECK(len >= 0);
+        CHECK(len < buff.size());
+        CHECK(c == rdf4cpp::datatypes::registry::util::from_chars<__int128, s>(std::string_view{buff.data(), static_cast<size_t>(len)}));
+    }
 }
 
 TEST_CASE("basics") {

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -17,7 +17,10 @@ namespace doctest {
         }
     };
 }
+static_assert(!rdf4cpp::util::detail::BoostNumber<__int128>);
 #endif
+static_assert(rdf4cpp::util::detail::BoostNumber<boost::multiprecision::checked_cpp_int>);
+static_assert(!rdf4cpp::util::detail::BoostNumber<int>);
 
 TEST_CASE_TEMPLATE("checked arithmetic signed", T, int32_t, int64_t, __int128, boost::multiprecision::checked_int256_t, boost::multiprecision::int256_t) {
     using namespace rdf4cpp::util::detail;
@@ -360,7 +363,7 @@ TEST_CASE("conversion") {
         str << Dec{50, 1};
         CHECK_EQ(str.view(), "5.0");
         // uses string conversion, so no more tests here
-        str << rdf4cpp::util::Int128{100};
+        str << rdf4cpp::util::BigInt{100};
         CHECK_EQ(str.view(), "5.0100");
     }
     SUBCASE("from double") {
@@ -371,7 +374,12 @@ TEST_CASE("conversion") {
         CHECK(Dec{1.0} == Dec{1, 0});
         CHECK(Dec{1.2} != Dec{12, 1}); // 1.2 can not be exactly represented as double but can be as decimal
         CHECK_EQ(static_cast<float>(Dec{1.0}), 1.0f);
-        CHECK_THROWS_AS([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()), std::overflow_error);
+        if constexpr (std::same_as<rdf4cpp::util::BigInt, rdf4cpp::util::Int128>) {
+            CHECK_THROWS_AS([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()), std::overflow_error);
+        }
+        else {
+            CHECK_NOTHROW([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()));
+        }
         CHECK(Dec(std::numeric_limits<double>::min()) > Dec(0, 0));
         CHECK(Dec(std::numeric_limits<double>::denorm_min()) > Dec(0, 0));
     }
@@ -405,14 +413,14 @@ TEST_CASE("conversion") {
         // no e notation allowed by rdf (xml) standard
     }
     SUBCASE("from Int128") {
-        CHECK(Dec{rdf4cpp::util::Int128{5}} == Dec{5, 0});
+        CHECK(Dec{rdf4cpp::util::BigInt{5}} == Dec{5, 0});
     }
     SUBCASE("to Int128") {
-        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{5, 0}) == rdf4cpp::util::Int128{5});
-        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{59, 1}) == rdf4cpp::util::Int128{5});
-        if constexpr (std::numeric_limits<rdf4cpp::util::Int128>::is_bounded) {
-            CHECK(static_cast<rdf4cpp::util::Int128>(Dec{std::numeric_limits<rdf4cpp::util::Int128>::max(), std::numeric_limits<rdf4cpp::util::Int128>::digits10}) ==
-                  (std::same_as<rdf4cpp::util::Int128, boost::multiprecision::checked_int128_t> ? rdf4cpp::util::Int128{3} : rdf4cpp::util::Int128{1})
+        CHECK(static_cast<rdf4cpp::util::BigInt>(Dec{5, 0}) == rdf4cpp::util::BigInt{5});
+        CHECK(static_cast<rdf4cpp::util::BigInt>(Dec{59, 1}) == rdf4cpp::util::BigInt{5});
+        if constexpr (std::numeric_limits<rdf4cpp::util::BigInt>::is_bounded) {
+            CHECK(static_cast<rdf4cpp::util::BigInt>(Dec{std::numeric_limits<rdf4cpp::util::BigInt>::max(), std::numeric_limits<rdf4cpp::util::BigInt>::digits10}) ==
+                  (std::same_as<rdf4cpp::util::BigInt, boost::multiprecision::checked_int128_t> ? rdf4cpp::util::BigInt{3} : rdf4cpp::util::BigInt{1})
             );
         }
     }

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -7,6 +7,119 @@ using Dec = rdf4cpp::BigDecimal<>;
 using DecI = rdf4cpp::BigDecimal<int32_t, uint32_t>;
 using RoundingMode = rdf4cpp::RoundingMode;
 
+TEST_CASE_TEMPLATE("checked arithmetic signed", T, int32_t, int64_t, __int128, boost::multiprecision::checked_int256_t, boost::multiprecision::int256_t) {
+    using namespace rdf4cpp::util::detail;
+
+    SUBCASE("add") {
+        auto eq = [](auto a, auto b, auto r) {
+            T re;
+            CHECK(add_checked<OverflowMode::Checked>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+            CHECK(add_checked<OverflowMode::UndefinedBehavior>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5, 5, 10);
+        eq(5, -5, 0);
+        [[maybe_unused]] T re = 0;
+        CHECK(add_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), T{1}, re) == true);
+    }
+    SUBCASE("sub") {
+        auto eq = [](auto a, auto b, auto r) {
+            T re;
+            CHECK(sub_checked<OverflowMode::Checked>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+            CHECK(sub_checked<OverflowMode::UndefinedBehavior>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5, -5, 10);
+        eq(5, 5, 0);
+        [[maybe_unused]] T re = 0;
+        CHECK(sub_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), T{-1}, re) == true);
+    }
+    SUBCASE("mul") {
+        auto eq = [](auto a, auto b, auto r) {
+            T re;
+            CHECK(mul_checked<OverflowMode::Checked>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+            CHECK(mul_checked<OverflowMode::UndefinedBehavior>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5, 5, 25);
+        eq(5, -5, -25);
+        [[maybe_unused]] T re = 0;
+        CHECK(mul_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), T{2}, re) == true);
+    }
+    SUBCASE("pow") {
+        auto eq = [](auto a, unsigned int b, auto r) {
+            T re;
+            CHECK(pow_checked<OverflowMode::Checked>(T{a}, b, re) == false);
+            CHECK(re == T{r});
+            CHECK(pow_checked<OverflowMode::UndefinedBehavior>(T{a}, b, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5, 3, 25*5);
+        eq(5, 2, 25);
+        [[maybe_unused]] T re = 0;
+        CHECK(pow_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), 2, re) == true);
+    }
+}
+TEST_CASE_TEMPLATE("checked arithmetic unsigned", T, uint32_t, uint64_t, unsigned __int128, boost::multiprecision::checked_uint256_t, boost::multiprecision::uint256_t) {
+    using namespace rdf4cpp::util::detail;
+
+    SUBCASE("add") {
+        auto eq = [](auto a, auto b, auto r) {
+            T re;
+            CHECK(add_checked<OverflowMode::Checked>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+            CHECK(add_checked<OverflowMode::UndefinedBehavior>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5u, 5u, 10u);
+        eq(5u, 10u, 15u);
+        [[maybe_unused]] T re = 0;
+        CHECK(add_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), T{1}, re) == true);
+    }
+    SUBCASE("sub") {
+        auto eq = [](auto a, auto b, auto r) {
+            T re;
+            CHECK(sub_checked<OverflowMode::Checked>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+            CHECK(sub_checked<OverflowMode::UndefinedBehavior>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5u, 3u, 2u);
+        eq(5u, 5u, 0u);
+        [[maybe_unused]] T re = 0;
+        CHECK(sub_checked<OverflowMode::Checked>(T{0}, std::numeric_limits<T>::max(), re) == true);
+    }
+    SUBCASE("mul") {
+        auto eq = [](auto a, auto b, auto r) {
+            T re;
+            CHECK(mul_checked<OverflowMode::Checked>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+            CHECK(mul_checked<OverflowMode::UndefinedBehavior>(T{a}, T{b}, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5u, 5u, 25u);
+        eq(5u, 15u, 5u*15u);
+        [[maybe_unused]] T re = 0;
+        CHECK(mul_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), T{2}, re) == true);
+    }
+    SUBCASE("pow") {
+        auto eq = [](auto a, unsigned int b, auto r) {
+            T re;
+            CHECK(pow_checked<OverflowMode::Checked>(T{a}, b, re) == false);
+            CHECK(re == T{r});
+            CHECK(pow_checked<OverflowMode::UndefinedBehavior>(T{a}, b, re) == false);
+            CHECK(re == T{r});
+        };
+        eq(5u, 3u, 25u*5u);
+        eq(5u, 2u, 25u);
+        [[maybe_unused]] T re = 0;
+        CHECK(pow_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), 2, re) == true);
+    }
+}
+
 TEST_CASE("basics") {
     SUBCASE("ctor and compare") {
         static_assert(rdf4cpp::BigDecimalBaseType<uint32_t>);
@@ -206,19 +319,19 @@ TEST_CASE("conversion") {
         CHECK_EQ(str.view(), "5.0");
         // uses string conversion, so no more tests here
     }
-    /*SUBCASE("from double") {
+    SUBCASE("from double") {
         CHECK(Dec{50.0} == Dec{50, 0});
         CHECK(Dec{-50.5} == Dec{-505, 1});
         CHECK(Dec{500000.0} == Dec{500000, 0});
         CHECK(Dec{0.0009765625} == Dec{"0.0009765625"});
         CHECK(Dec{1.0} == Dec{1, 0});
+        CHECK(Dec{1.2} == Dec{12, 1});
         CHECK_EQ(static_cast<float>(Dec{1.0}), 1.0f);
-    }*/
+        CHECK_THROWS_AS([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()), std::overflow_error);
+    }
     SUBCASE("to double") {
-        CHECK(boost::multiprecision::checked_int1024_t {std::numeric_limits<double>::max()} != boost::multiprecision::checked_int1024_t {});
         CHECK_EQ(static_cast<double>(Dec{50, 0}), 50.0);
         CHECK_EQ(static_cast<double>(Dec{500, 1}), 50.0);
-        CHECK_EQ(static_cast<double>(Dec{static_cast<boost::multiprecision::checked_int128_t>(std::numeric_limits<double>::max()) * 100, 2}), std::numeric_limits<double>::max());
     }
     SUBCASE("to float") {
         CHECK_EQ(static_cast<float>(Dec{50, 0}), 50.0f);
@@ -246,10 +359,10 @@ TEST_CASE("conversion") {
         // no e notation allowed by rdf (xml) standard
     }
     SUBCASE("from cpp_int") {
-        CHECK(Dec{boost::multiprecision::checked_int128_t{5}} == Dec{5, 0});
+        CHECK(Dec{rdf4cpp::util::Int128{5}} == Dec{5, 0});
     }
     SUBCASE("to cpp_int") {
-        CHECK(static_cast<boost::multiprecision::checked_int128_t>(Dec{5, 0}) == boost::multiprecision::cpp_int{5});
-        CHECK(static_cast<boost::multiprecision::checked_int128_t>(Dec{59, 1}) == boost::multiprecision::cpp_int{5});
+        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{5, 0}) == rdf4cpp::util::Int128{5});
+        CHECK(static_cast<rdf4cpp::util::Int128>(Dec{59, 1}) == rdf4cpp::util::Int128{5});
     }
 }

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -206,18 +206,19 @@ TEST_CASE("conversion") {
         CHECK_EQ(str.view(), "5.0");
         // uses string conversion, so no more tests here
     }
-    SUBCASE("from double") {
+    /*SUBCASE("from double") {
         CHECK(Dec{50.0} == Dec{50, 0});
         CHECK(Dec{-50.5} == Dec{-505, 1});
         CHECK(Dec{500000.0} == Dec{500000, 0});
         CHECK(Dec{0.0009765625} == Dec{"0.0009765625"});
         CHECK(Dec{1.0} == Dec{1, 0});
         CHECK_EQ(static_cast<float>(Dec{1.0}), 1.0f);
-    }
+    }*/
     SUBCASE("to double") {
+        CHECK(boost::multiprecision::checked_int1024_t {std::numeric_limits<double>::max()} != boost::multiprecision::checked_int1024_t {});
         CHECK_EQ(static_cast<double>(Dec{50, 0}), 50.0);
         CHECK_EQ(static_cast<double>(Dec{500, 1}), 50.0);
-        CHECK_EQ(static_cast<double>(Dec{static_cast<boost::multiprecision::cpp_int>(std::numeric_limits<double>::max()) * 100, 2}), std::numeric_limits<double>::max());
+        CHECK_EQ(static_cast<double>(Dec{static_cast<boost::multiprecision::checked_int128_t>(std::numeric_limits<double>::max()) * 100, 2}), std::numeric_limits<double>::max());
     }
     SUBCASE("to float") {
         CHECK_EQ(static_cast<float>(Dec{50, 0}), 50.0f);
@@ -245,10 +246,10 @@ TEST_CASE("conversion") {
         // no e notation allowed by rdf (xml) standard
     }
     SUBCASE("from cpp_int") {
-        CHECK(Dec{boost::multiprecision::cpp_int{5}} == Dec{5, 0});
+        CHECK(Dec{boost::multiprecision::checked_int128_t{5}} == Dec{5, 0});
     }
     SUBCASE("to cpp_int") {
-        CHECK(static_cast<boost::multiprecision::cpp_int>(Dec{5, 0}) == boost::multiprecision::cpp_int{5});
-        CHECK(static_cast<boost::multiprecision::cpp_int>(Dec{59, 1}) == boost::multiprecision::cpp_int{5});
+        CHECK(static_cast<boost::multiprecision::checked_int128_t>(Dec{5, 0}) == boost::multiprecision::cpp_int{5});
+        CHECK(static_cast<boost::multiprecision::checked_int128_t>(Dec{59, 1}) == boost::multiprecision::cpp_int{5});
     }
 }

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -7,6 +7,18 @@ using Dec = rdf4cpp::BigDecimal<>;
 using DecI = rdf4cpp::BigDecimal<int32_t, uint32_t>;
 using RoundingMode = rdf4cpp::RoundingMode;
 
+#ifdef __SIZEOF_INT128__
+namespace doctest {
+    template<> struct StringMaker<__int128> {
+        static String convert(const __int128& value) {
+            std::stringstream s{};
+            ::operator<<(s, value);
+            return doctest::String{s.view().data(), static_cast<unsigned int>(s.view().size())};
+        }
+    };
+}
+#endif
+
 TEST_CASE_TEMPLATE("checked arithmetic signed", T, int32_t, int64_t, __int128, boost::multiprecision::checked_int256_t, boost::multiprecision::int256_t) {
     using namespace rdf4cpp::util::detail;
 
@@ -318,6 +330,8 @@ TEST_CASE("conversion") {
         str << Dec{50, 1};
         CHECK_EQ(str.view(), "5.0");
         // uses string conversion, so no more tests here
+        str << rdf4cpp::util::Int128{100};
+        CHECK_EQ(str.view(), "5.0100");
     }
     SUBCASE("from double") {
         CHECK(Dec{50.0} == Dec{50, 0});
@@ -360,11 +374,16 @@ TEST_CASE("conversion") {
         CHECK_THROWS_AS(Dec{"5.5+5"}, rdf4cpp::InvalidNode);
         // no e notation allowed by rdf (xml) standard
     }
-    SUBCASE("from cpp_int") {
+    SUBCASE("from Int128") {
         CHECK(Dec{rdf4cpp::util::Int128{5}} == Dec{5, 0});
     }
-    SUBCASE("to cpp_int") {
+    SUBCASE("to Int128") {
         CHECK(static_cast<rdf4cpp::util::Int128>(Dec{5, 0}) == rdf4cpp::util::Int128{5});
         CHECK(static_cast<rdf4cpp::util::Int128>(Dec{59, 1}) == rdf4cpp::util::Int128{5});
+        if constexpr (std::numeric_limits<rdf4cpp::util::Int128>::is_bounded) {
+            CHECK(static_cast<rdf4cpp::util::Int128>(Dec{std::numeric_limits<rdf4cpp::util::Int128>::max(), std::numeric_limits<rdf4cpp::util::Int128>::digits10}) ==
+                  (std::same_as<rdf4cpp::util::Int128, boost::multiprecision::checked_int128_t> ? rdf4cpp::util::Int128{3} : rdf4cpp::util::Int128{1})
+            );
+        }
     }
 }

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -24,7 +24,7 @@ static_assert(!rdf4cpp::util::detail::BoostNumber<__int128>);
 static_assert(rdf4cpp::util::detail::BoostNumber<boost::multiprecision::checked_cpp_int>);
 static_assert(!rdf4cpp::util::detail::BoostNumber<int>);
 
-TEST_CASE_TEMPLATE("checked arithmetic signed", T, int32_t, int64_t, __int128, boost::multiprecision::checked_int256_t, boost::multiprecision::int256_t) {
+TEST_CASE_TEMPLATE("checked arithmetic signed", T, int32_t, int64_t, __int128, boost::multiprecision::checked_int256_t) {
     using namespace rdf4cpp::util::detail;
 
     SUBCASE("add") {
@@ -80,7 +80,7 @@ TEST_CASE_TEMPLATE("checked arithmetic signed", T, int32_t, int64_t, __int128, b
         CHECK(pow_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), 2, re) == true);
     }
 }
-TEST_CASE_TEMPLATE("checked arithmetic unsigned", T, uint32_t, uint64_t, unsigned __int128, boost::multiprecision::checked_uint256_t, boost::multiprecision::uint256_t) {
+TEST_CASE_TEMPLATE("checked arithmetic unsigned", T, uint32_t, uint64_t, unsigned __int128, boost::multiprecision::checked_uint256_t) {
     using namespace rdf4cpp::util::detail;
 
     SUBCASE("add") {

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -322,12 +322,14 @@ TEST_CASE("conversion") {
     SUBCASE("from double") {
         CHECK(Dec{50.0} == Dec{50, 0});
         CHECK(Dec{-50.5} == Dec{-505, 1});
-        CHECK(Dec{500000.0} == Dec{500000, 0});
+        CHECK(Dec{5000000000000000000.0} == Dec{5000000000000000000, 0});
         CHECK(Dec{0.0009765625} == Dec{"0.0009765625"});
         CHECK(Dec{1.0} == Dec{1, 0});
-        CHECK(Dec{1.2} == Dec{12, 1});
+        CHECK(Dec{1.2} != Dec{12, 1}); // 1.2 can not be exactly represented as double but can be as decimal
         CHECK_EQ(static_cast<float>(Dec{1.0}), 1.0f);
         CHECK_THROWS_AS([[maybe_unused]] auto _ = Dec(std::numeric_limits<double>::max()), std::overflow_error);
+        CHECK(Dec(std::numeric_limits<double>::min()) > Dec(0, 0));
+        CHECK(Dec(std::numeric_limits<double>::denorm_min()) > Dec(0, 0));
     }
     SUBCASE("to double") {
         CHECK_EQ(static_cast<double>(Dec{50, 0}), 50.0);

--- a/tests/util/tests_BigDecimal.cpp
+++ b/tests/util/tests_BigDecimal.cpp
@@ -165,6 +165,18 @@ TEST_CASE_TEMPLATE("checked casting", T, uint32_t, uint64_t, unsigned __int128, 
     CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<T>::max(), i8) == true);
     CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<uint8_t>::max(), t) == false);
     CHECK(t == std::numeric_limits<uint8_t>::max());
+
+    CHECK(cast_checked<OverflowMode::Checked>(0.0, t) == false);
+    CHECK(t == 0);
+    CHECK(cast_checked<OverflowMode::Checked>(static_cast<double>(std::numeric_limits<T>::max()) / 2, t) == false);
+    CHECK(t < std::numeric_limits<T>::max());
+    if constexpr (!rdf4cpp::util::detail::BoostNumber<T>) {
+        CHECK(cast_checked<OverflowMode::Checked>(static_cast<double>(std::numeric_limits<T>::min()), t) == false);
+        CHECK(t == std::numeric_limits<T>::min());
+    }
+    CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<double>::quiet_NaN(), t) == true);
+    CHECK(cast_checked<OverflowMode::Checked>(std::numeric_limits<double>::infinity(), t) == true);
+    CHECK(cast_checked<OverflowMode::Checked>(static_cast<double>(std::numeric_limits<T>::max()) * 2, t) == true);
 }
 
 TEST_CASE("int128 to_chars") {


### PR DESCRIPTION
changes date/time 128 bit integer from boost to builtin `__int128`, to make calculations a lot faster.

while the builtin has a smaller range than boost, both are bigger than what the `int64_t` year allows. therefore the usable range of date/time types stays the same.

also fixes some possible (but very unlikely in regular use) overflow errors in date/time calculations (to trigger them, you need to use very big numbers, at least several orders of magnitude bigger than the end of the universe).