### PR TITLE
Update dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -30,17 +30,17 @@ class Recipe(ConanFile):
     generators = ("CMakeDeps", "CMakeToolchain")
 
     def requirements(self):
-        self.requires("boost/1.86.0", transitive_headers=True, libs=False)
-        self.requires("expected-lite/0.8.0", transitive_headers=True)
-        self.requires("pcre2/10.44", options={"support_jit": True})
+        self.requires("boost/1.90.0", transitive_headers=True, libs=False)
+        self.requires("expected-lite/0.9.0", transitive_headers=True)
+        self.requires("pcre2/10.47", options={"support_jit": True})
         self.requires("openssl/3.6.3")
         self.requires("uni-algo/1.2.0")
-        self.requires("highway/1.2.0")
-        self.requires("dice-hash/0.4.11", transitive_headers=True)
-        self.requires("dice-sparse-map/0.2.9", transitive_headers=True)
+        self.requires("highway/1.4.0")
+        self.requires("dice-hash/0.4.12", transitive_headers=True)
+        self.requires("dice-sparse-map/0.2.11", transitive_headers=True)
         self.requires("dice-template-library/1.19.0", transitive_headers=True)
-        self.requires("libxml2/2.15.0", options={"iconv": False})
-        self.requires("simdjson/4.2.4")
+        self.requires("libxml2/2.15.3", options={"iconv": False})
+        self.requires("simdjson/4.6.3")
 
         if self.options.with_test_deps:
             self.test_requires("doctest/2.4.11")


### PR DESCRIPTION
Bumps the conan dependencies that have newer releases. `doctest`, `nanobench`, `libcurl`, `openssl`, `uni-algo` and `dice-template-library` stay where they are.

| package | from | to |
|---|---|---|
| boost | 1.86.0 | 1.90.0 |
| expected-lite | 0.8.0 | 0.9.0 |
| pcre2 | 10.44 | 10.47 |
| highway | 1.2.0 | 1.4.0 |
| dice-hash | 0.4.11 | 0.4.12 |
| dice-sparse-map | 0.2.9 | 0.2.11 |
| libxml2 | 2.15.0 | 2.15.3 |
| simdjson | 4.2.4 | 4.6.3 |

`dice-template-library` is left at 1.19.0 on purpose. The current release is 2.8.0, a major version, so it needs its own PR.

Note that `dice-hash` 0.4.12 adds `rapidhash` as a new transitive dependency. It resolves from the `dice-group` remote.

## Verification

clang 21 RelWithDebInfo in the `tentris-dev-env` container, aarch64 Linux:

- build of library, tests and examples is clean, no new warnings
- `ctest -j14`: 52 of 52 tests pass

No source changes were needed.