### PR TITLE
Build against dice-template-library 2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class Recipe(ConanFile):
         self.requires("highway/1.2.0")
         self.requires("dice-hash/0.4.11", transitive_headers=True)
         self.requires("dice-sparse-map/0.2.9", transitive_headers=True)
-        self.requires("dice-template-library/1.19.0", transitive_headers=True)
+        self.requires("dice-template-library/2.8.0", transitive_headers=True)
         self.requires("libxml2/2.15.0", options={"iconv": False})
         self.requires("simdjson/4.2.4")
 

--- a/tests/util/tests_Anonymizer.cpp
+++ b/tests/util/tests_Anonymizer.cpp
@@ -8,11 +8,22 @@
 #include <rdf4cpp/query/Variable.hpp>
 #include <rdf4cpp/namespaces/FOAF.hpp>
 
-#include <dice/template-library/ranges.hpp>
+#include <unordered_set>
+#include <vector>
 
 TEST_SUITE("anonymizer") {
     using namespace rdf4cpp;
     using namespace rdf4cpp::shorthands;
+
+    /**
+     * Checks that no two elements of the given vector are equal.
+     * Equality is the element's own operator==, and lookup goes through std::hash.
+     */
+    template<typename T>
+    [[nodiscard]] bool all_distinct(std::vector<T> const &elements) {
+        std::unordered_set<T> const seen{elements.begin(), elements.end()};
+        return seen.size() == elements.size();
+    }
 
     TEST_CASE("sanity check") {
         util::Anonymizer anony{};
@@ -37,7 +48,7 @@ TEST_SUITE("anonymizer") {
         CHECK_NE(anon_lit, lit);
 
         // generates distinct nodes for all cases
-        CHECK((std::vector<Node>{anon_null, anon_default_graph, anon_iri, anon_bn, anon_lit, iri, bn, lit} | dice::template_library::all_distinct()));
+        CHECK(all_distinct(std::vector<Node>{anon_null, anon_default_graph, anon_iri, anon_bn, anon_lit, iri, bn, lit}));
 
         // same result for second call
         CHECK_EQ(anony.anonymize(iri), anon_iri);
@@ -92,7 +103,7 @@ _:customer2 a foaf:Person ;
         auto const m1 = first_solution(anon, query::TriplePattern{c1, foaf_mbox, query::Variable{"n"}})[0];
         auto const m2 = first_solution(anon, query::TriplePattern{c2, foaf_mbox, query::Variable{"n"}})[0];
 
-        CHECK((std::vector{c1, c2, n1, n2, m1, m2} | dice::template_library::all_distinct()));
+        CHECK(all_distinct(std::vector{c1, c2, n1, n2, m1, m2}));
     }
 
     TEST_CASE("dataset") {
@@ -135,6 +146,6 @@ _:customer2 a foaf:Person ;
         auto const m1 = first_solution(anon, query::QuadPattern{query::Variable{"g"}, c1, foaf_mbox, query::Variable{"n"}})[1];
         auto const m2 = first_solution(anon, query::QuadPattern{query::Variable{"g"}, c2, foaf_mbox, query::Variable{"n"}})[1];
 
-        CHECK((std::vector{c1, c2, n1, n2, m1, m2} | dice::template_library::all_distinct()));
+        CHECK(all_distinct(std::vector{c1, c2, n1, n2, m1, m2}));
     }
 }


### PR DESCRIPTION
dice-template-library 1.19.0 to 2.8.0.

2.0.0 is the only release in that range with breaking changes, and rdf4cpp uses none of the three: no `template_library::generator`, no `next_to_range`, and no `integral_template_{tuple,variant}`, whose upper bound went from inclusive to exclusive. Releases 2.1.0 through 2.8.0 ship without a migration guide, checked one by one.

### One adaptation was needed

2.x marks `all_distinct` deprecated, and the build turns deprecation warnings into errors, so the pin alone does not compile.

`tests_Anonymizer.cpp` used it through a local helper. It now collects the elements in a `std::unordered_set` and compares the size against the input, so lookup goes through `std::hash` and `operator==`. A `std::set` would be wrong here: `Node` has a partial order, so incomparable nodes would compare equivalent and be reported as duplicates.

### Order across the repos

tentris-lib pins dice-template-library with `force=True`, so it dictates the version for the whole dependency graph, hypertrie's headers included. hypertrie is header only and its `integral_template_tuple` uses carry inclusive upper bounds, so **tentris-lib cannot follow to 2.x until a ported hypertrie is released**. A site that indexes the top element would fail to compile, and a site that only iterates would silently lose its top element.

This PR is not affected by that. rdf4cpp is correct under either major, so tentris-lib forcing 1.x onto it in the meantime keeps working.

*(prepared with claude)*
