### PR TITLE
Compare nodes of different term kinds as false instead of a type error

### DIFF
--- a/src/rdf4cpp/Node.cpp
+++ b/src/rdf4cpp/Node.cpp
@@ -128,7 +128,10 @@ TriBool Node::eq_impl(Node const &other) const {
     }
 
     if (handle_.type() != other.handle_.type()) {
-        return TriBool::Err;
+        // "produces a type error if the arguments are both literal but are not the same RDF term; returns FALSE otherwise"
+        // - https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal
+        // Two nodes of different kinds are not both literal, so the type error does not apply.
+        return TriBool::False;
     }
 
     using storage::identifier::RDFNodeType;

--- a/tests/nodes/tests_Node.cpp
+++ b/tests/nodes/tests_Node.cpp
@@ -217,6 +217,27 @@ TEST_CASE("effective boolean value") {
     CHECK(null_bnode.ebv() == TriBool::Err);
 }
 
+TEST_CASE("RDFterm-equal: mixed term kinds give a boolean, not an error") {
+    // SPARQL 1.1 section 17.4.1.7: RDFterm-equal returns TRUE for the same term.
+    // It produces a type error only when both arguments are literals.
+    // It returns FALSE otherwise. A blank node compared with an IRI is FALSE,
+    // and != is fn:not(RDFterm-equal), so != must be TRUE there.
+    Node const bnode = BlankNode{"b0"};
+    Node const iri = IRI{"http://example.org/Person"};
+    Node const lit = Literal::make_simple("hello");
+
+    CHECK(bnode.eq(iri) == TriBool::False);
+    CHECK(bnode.ne(iri) == TriBool::True);
+    CHECK(iri.eq(bnode) == TriBool::False);
+    CHECK(iri.ne(bnode) == TriBool::True);
+    CHECK(iri.eq(lit) == TriBool::False);
+    CHECK(lit.ne(bnode) == TriBool::True);
+
+    // the FILTER path: as_ne must produce "true"^^xsd:boolean, not the null literal
+    CHECK(!bnode.as_ne(iri).null());
+    CHECK(bnode.as_ne(iri).ebv() == TriBool::True);
+}
+
 TEST_CASE("IRI UUID") {
     IRI uuid = IRI::make_uuid();
     IRI uuid2 = IRI::make_uuid();


### PR DESCRIPTION
## Defect

`Node::eq_impl` returns `TriBool::Err` whenever the two operands have different term kinds
(`src/rdf4cpp/Node.cpp`). SPARQL 1.1 section 17.3 maps `=` to RDFterm-equal and `!=` to
`fn:not(RDFterm-equal)`. Section 17.4.1.7 confines the type error to two literals:

> Returns TRUE if term1 and term2 are the same RDF term as defined in Resource Description
> Framework (RDF): Concepts and Abstract Syntax; produces a type error if the arguments are
> both literal but are not the same RDF term; returns FALSE otherwise.

A blank node and an IRI are not both literal, so `=` is FALSE and `!=` is TRUE there. Today
the `Err` propagates through `ne`, through `as_ne` (which turns it into the null literal) and
through the effective boolean value, so a `FILTER (?s != ?o)` eliminates every solution with
a blank node on one side and an IRI on the other.

Blast radius: `=`, `!=`, `as_eq` and `as_ne` for every pair of two different term kinds, in
both operand positions, plus every composite expression such a comparison feeds (`!`, `||`,
`IF`, `COALESCE`, `BIND`). The ordering operators are not affected: section 17.3 has no row
for non-literal operands, so their type error is correct.

The branch has been there since 8b9e4fa "Fix: node comparisons (#312)" and is in every
release since, v0.2.2 included.

## Fix

The kind-mismatch branch returns `TriBool::False`. Two nodes of different kinds can never be
the both-literals error case; that case lives in `Literal::eq`.

## Measured impact

On the DBLP dump (503.9 M triples), `SELECT (COUNT(?s) AS ?count) { ?s rdf:type ?o . FILTER (?s != ?o) }`
loses every solution with a blank-node subject, 79.8 percent of the answer.
