### PR TITLE
Perf improvement for compensated sum

### DIFF
--- a/src/rdf4cpp/CompensatedSum.cpp
+++ b/src/rdf4cpp/CompensatedSum.cpp
@@ -30,6 +30,20 @@ void CompensatedSum::add(Literal const &lit, uint64_t multiplicity) {
 }
 
 void CompensatedSum::add(DeferredLiteral const &value, uint64_t multiplicity) {
+    if (multiplicity == 1) {
+        add_once(value);
+        return;
+    }
+
+    if (is_exact(value.datatype)) {
+        // use multiplication by multiplicity instead of loop
+        // no precision loss possible because the dt is exact
+        auto const mult = make_deferred_from_multiplicity(multiplicity, value.datatype);
+        add_once(numeric_mul_deferred(value, mult, node_storage_));
+        return;
+    }
+
+    // datatype is not exact, multiplying with multiplicity would result in precision loss
     // assumption: multiplicity is usually small
     while (multiplicity > 0) {
         add_once(value);

--- a/src/rdf4cpp/DeferredLiteral.cpp
+++ b/src/rdf4cpp/DeferredLiteral.cpp
@@ -18,6 +18,30 @@ DeferredLiteral make_deferred_from_literal(Literal const &lit) {
     return DeferredLiteral{lit.value(), lit.datatype()};
 }
 
+static DeferredLiteral make_deferred_from_multiplicity_impl(uint64_t multiplicity, datatypes::registry::DatatypeIDView const &dt_view, storage::DynNodeStoragePtr node_storage) {
+    auto const *entry = datatypes::registry::DatatypeRegistry::get_entry(dt_view);
+    if (entry == nullptr || !entry->numeric_ops.has_value()) {
+        return DeferredLiteral{};
+    }
+
+    if (entry->numeric_ops->is_stub()) {
+        auto const impl_dt = datatypes::registry::DatatypeRegistry::get_numeric_op_impl_conversion(*entry).target_type_id;
+        return make_deferred_from_multiplicity_impl(multiplicity, impl_dt, node_storage);
+    }
+
+    auto const &impl_ops = entry->numeric_ops->get_impl();
+    auto res = impl_ops.from_multiplicity_fptr(multiplicity);
+    if (!res.has_value()) {
+        return DeferredLiteral{};
+    }
+
+    return deferred_detail::make_deferred_from_value(std::move(*res), dt_view, node_storage);
+}
+
+DeferredLiteral make_deferred_from_multiplicity(uint64_t multiplicity, IRI const &datatype) {
+    return make_deferred_from_multiplicity_impl(multiplicity, datatype, datatype.backend_handle().storage());
+}
+
 Literal materialize_deferred(DeferredLiteral value, storage::DynNodeStoragePtr node_storage) {
     return Literal::make_typed_from_value(std::move(value.value), value.datatype, node_storage);
 }

--- a/src/rdf4cpp/DeferredLiteral.hpp
+++ b/src/rdf4cpp/DeferredLiteral.hpp
@@ -127,6 +127,15 @@ template<datatypes::LiteralDatatype T>
 [[nodiscard]] DeferredLiteral make_deferred_from_literal(Literal const &lit);
 
 /**
+ * Make a deferred literal by converting the given multiplicity to the given datatype
+ *
+ * @param multiplicity multiplicity
+ * @param datatype datatype iri
+ * @return deferred literal corresponding to the multiplicity (or null-literal if the multiplicity was not representable)
+ */
+[[nodiscard]] DeferredLiteral make_deferred_from_multiplicity(uint64_t multiplicity, IRI const &datatype);
+
+/**
  * @brief Places a DeferredLiteral into node_storage
  * @return the resulting literal, or the null-literal if value is the null-value
  */

--- a/src/rdf4cpp/Literal.cpp
+++ b/src/rdf4cpp/Literal.cpp
@@ -252,6 +252,10 @@ Literal Literal::make_boolean(TriBool const b, storage::DynNodeStoragePtr node_s
     return Literal::make_typed_from_value<datatypes::xsd::Boolean>(b == TriBool::True, node_storage);
 }
 
+Literal Literal::make_from_multiplicity(uint64_t multiplicity, IRI const &datatype, storage::DynNodeStoragePtr node_storage) {
+    return materialize_deferred(make_deferred_from_multiplicity(multiplicity, datatype), node_storage);
+}
+
 Literal Literal::make_string_uuid(storage::DynNodeStoragePtr node_storage) {
     boost::uuids::random_generator_mt19937 gen{};
     boost::uuids::uuid u = gen();

--- a/src/rdf4cpp/Literal.hpp
+++ b/src/rdf4cpp/Literal.hpp
@@ -476,7 +476,35 @@ public:
      *
      * @return the literal form of the given boolean
      */
-    static Literal make_boolean(TriBool b, storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+    [[nodiscard]] static Literal make_boolean(TriBool b, storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+
+    /**
+     * Make a literal by converting the given multiplicity to the given datatype
+     *
+     * @param multiplicity multiplicity
+     * @param datatype datatype iri
+     * @param node_storage node storage where to place literal
+     * @return literal corresponding to the multiplicity (or null-literal if the multiplicity was not representable)
+     */
+    [[nodiscard]] static Literal make_from_multiplicity(uint64_t multiplicity, IRI const &datatype, storage::DynNodeStoragePtr node_storage = storage::default_node_storage);
+
+    /**
+     * See other overload
+     */
+    template<datatypes::NumericLiteralDatatype T>
+    [[nodiscard]] static Literal make_from_multiplicity(uint64_t multiplicity, storage::DynNodeStoragePtr node_storage = storage::default_node_storage) {
+        if constexpr (datatypes::NumericStub<T>) {
+            return Literal::make_from_multiplicity<typename T::numeric_impl_type>(multiplicity, node_storage);
+        } else {
+            // numeric impl
+            auto res = T::from_multiplicity(multiplicity);
+            if (!res.has_value()) {
+                return Literal{};
+            }
+
+            return Literal::make_typed_from_value<T>(*res, node_storage);
+        }
+    }
 
     /**
      * creates a new string Literal containing a random UUID (Universally Unique IDentifier)

--- a/src/rdf4cpp/datatypes/LiteralDatatype.hpp
+++ b/src/rdf4cpp/datatypes/LiteralDatatype.hpp
@@ -40,7 +40,7 @@ enum struct DynamicError {
  * A type that is not explicitly a LiteralDatatype but fulfills the requirements for being impl-numeric (see NumericStubLiteralDatatype)
  */
 template<typename LiteralDatatypeImpl>
-concept NumericImpl = requires(typename LiteralDatatypeImpl::cpp_type const &lhs, typename LiteralDatatypeImpl::cpp_type const &rhs) {
+concept NumericImpl = requires(typename LiteralDatatypeImpl::cpp_type const &lhs, typename LiteralDatatypeImpl::cpp_type const &rhs, uint64_t mult) {
                           requires LiteralDatatypeOrUndefined<typename LiteralDatatypeImpl::add_result>;
                           requires LiteralDatatypeOrUndefined<typename LiteralDatatypeImpl::sub_result>;
                           requires LiteralDatatypeOrUndefined<typename LiteralDatatypeImpl::mul_result>;
@@ -63,6 +63,7 @@ concept NumericImpl = requires(typename LiteralDatatypeImpl::cpp_type const &lhs
                           { LiteralDatatypeImpl::pos(lhs) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::pos_result_cpp_type, DynamicError>>;
                           { LiteralDatatypeImpl::neg(lhs) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::neg_result_cpp_type, DynamicError>>;
                           { LiteralDatatypeImpl::is_inf(lhs) } -> std::convertible_to<bool>;
+                          { LiteralDatatypeImpl::from_multiplicity(mult) } -> std::convertible_to<nonstd::expected<typename LiteralDatatypeImpl::cpp_type, DynamicError>>;
                       };
 
 /**

--- a/src/rdf4cpp/datatypes/owl/Rational.cpp
+++ b/src/rdf4cpp/datatypes/owl/Rational.cpp
@@ -94,6 +94,12 @@ nonstd::expected<capabilities::Numeric<owl_rational>::ceil_result_cpp_type, Dyna
     auto const rest = numerator(operand) % denominator(operand);
     return integral + (rest != 0);
 }
+
+template<>
+nonstd::expected<capabilities::Default<owl_rational>::cpp_type, DynamicError> capabilities::Numeric<owl_rational>::from_multiplicity(uint64_t multiplicity) noexcept {
+    return cpp_type{multiplicity}; // any 64bit integer is exactly representable in boost::multiprecision::cpp_rational
+}
+
 #endif
 
 template struct LiteralDatatypeImpl<owl_rational,

--- a/src/rdf4cpp/datatypes/owl/Rational.hpp
+++ b/src/rdf4cpp/datatypes/owl/Rational.hpp
@@ -40,6 +40,10 @@ nonstd::expected<capabilities::Numeric<owl_rational>::floor_result_cpp_type, Dyn
 
 template<>
 nonstd::expected<capabilities::Numeric<owl_rational>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<owl_rational>::ceil(cpp_type const &operand) noexcept;
+
+template<>
+nonstd::expected<capabilities::Default<owl_rational>::cpp_type, DynamicError> capabilities::Numeric<owl_rational>::from_multiplicity(uint64_t multiplicity) noexcept;
+
 #endif
 
 extern template struct LiteralDatatypeImpl<owl_rational,

--- a/src/rdf4cpp/datatypes/owl/Real.cpp
+++ b/src/rdf4cpp/datatypes/owl/Real.cpp
@@ -1,6 +1,8 @@
 #include "Real.hpp"
 #include <rdf4cpp/InvalidNode.hpp>
 
+#include <boost/numeric/conversion/cast.hpp>
+
 namespace rdf4cpp::datatypes::registry {
 
 #ifndef DOXYGEN_PARSER
@@ -48,6 +50,12 @@ template<>
 nonstd::expected<capabilities::Numeric<owl_real>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<owl_real>::ceil(cpp_type const &operand) noexcept {
     return boost::multiprecision::ceil(operand);
 }
+
+template<>
+nonstd::expected<capabilities::Default<owl_real>::cpp_type, DynamicError> capabilities::Numeric<owl_real>::from_multiplicity(uint64_t multiplicity) noexcept {
+    return multiplicity; // any 64bit integer is exactly representable in a IEEE quad float (113 bit mantissa)
+}
+
 #endif
 
 template struct LiteralDatatypeImpl<owl_real,

--- a/src/rdf4cpp/datatypes/owl/Real.hpp
+++ b/src/rdf4cpp/datatypes/owl/Real.hpp
@@ -36,6 +36,10 @@ nonstd::expected<capabilities::Numeric<owl_real>::floor_result_cpp_type, Dynamic
 
 template<>
 nonstd::expected<capabilities::Numeric<owl_real>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<owl_real>::ceil(cpp_type const &operand) noexcept;
+
+template<>
+nonstd::expected<capabilities::Default<owl_real>::cpp_type, DynamicError> capabilities::Numeric<owl_real>::from_multiplicity(uint64_t multiplicity) noexcept;
+
 #endif
 
 extern template struct LiteralDatatypeImpl<owl_real,

--- a/src/rdf4cpp/datatypes/registry/DatatypeRegistry.hpp
+++ b/src/rdf4cpp/datatypes/registry/DatatypeRegistry.hpp
@@ -64,6 +64,8 @@ struct DatatypeRegistry {
      */
     using compare_inlined_fptr_t = std::partial_ordering (*)(storage::identifier::LiteralID, storage::identifier::LiteralID) noexcept;
 
+    using from_multiplicity_fptr_t = nonstd::expected<std::any, DynamicError> (*)(uint64_t multiplicity) noexcept;
+
     struct NumericOpsImpl {
         nullop_fptr_t zero_value_fptr; // 0
         nullop_fptr_t one_value_fptr; // 1
@@ -84,6 +86,8 @@ struct DatatypeRegistry {
         predicate_fptr_t is_inf_fptr; // is_inf(a)
 
         compare_fptr_t magnitude_compare_fptr; // compare(abs(a), abs(b)), only available if the datatype is also comparable
+
+        from_multiplicity_fptr_t from_multiplicity_fptr; // from_multiplicity(n)
     };
 
     struct NumericOpsStub {
@@ -829,7 +833,10 @@ DatatypeRegistry::NumericOpsImpl DatatypeRegistry::make_numeric_ops_impl() noexc
                 } else {
                     return nullptr;
                 }
-            }()};
+            }(),
+            .from_multiplicity_fptr = [](uint64_t multiplicity) noexcept -> nonstd::expected<std::any, DynamicError> {
+                return detail::map_expected(LiteralDatatype_t::from_multiplicity(multiplicity));
+            }};
 }
 
 template<datatypes::TimepointLiteralDatatype LiteralDatatype_t>

--- a/src/rdf4cpp/datatypes/registry/LiteralDatatypeImpl.hpp
+++ b/src/rdf4cpp/datatypes/registry/LiteralDatatypeImpl.hpp
@@ -300,6 +300,10 @@ struct Numeric {
             return false;
         }
     }
+
+    static nonstd::expected<cpp_type, DynamicError> from_multiplicity([[maybe_unused]] uint64_t multiplicity) noexcept {
+        return nonstd::make_unexpected(DynamicError::Unsupported);
+    }
 };
 
 /**

--- a/src/rdf4cpp/datatypes/registry/util/ConstexprString.hpp
+++ b/src/rdf4cpp/datatypes/registry/util/ConstexprString.hpp
@@ -38,6 +38,10 @@ struct ConstexprString {
         // implicitly null terminated by default init of array
     }
 
+    [[nodiscard]] constexpr char const *c_str() const noexcept {
+        return value.data(); // always null-terminated
+    }
+
     [[nodiscard]] constexpr char const *data() const noexcept {
         return value.data();
     }

--- a/src/rdf4cpp/datatypes/xsd/Decimal.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.cpp
@@ -124,6 +124,11 @@ nonstd::expected<capabilities::Numeric<xsd_decimal>::ceil_result_cpp_type, Dynam
 }
 
 template<>
+nonstd::expected<capabilities::Default<xsd_decimal>::cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::from_multiplicity(uint64_t multiplicity) noexcept {
+    return cpp_type{multiplicity}; // any 64bit integer is exactly representable in BigDecimal
+}
+
+template<>
 bool capabilities::Logical<xsd_decimal>::effective_boolean_value(cpp_type const &value) noexcept {
     return value != 0;
 }

--- a/src/rdf4cpp/datatypes/xsd/Decimal.hpp
+++ b/src/rdf4cpp/datatypes/xsd/Decimal.hpp
@@ -68,6 +68,9 @@ template<>
 nonstd::expected<capabilities::Numeric<xsd_decimal>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::ceil(cpp_type const &operand) noexcept;
 
 template<>
+nonstd::expected<capabilities::Default<xsd_decimal>::cpp_type, DynamicError> capabilities::Numeric<xsd_decimal>::from_multiplicity(uint64_t multiplicity) noexcept;
+
+template<>
 bool capabilities::Logical<xsd_decimal>::effective_boolean_value(cpp_type const &value) noexcept;
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Double.cpp
@@ -50,13 +50,15 @@ nonstd::expected<capabilities::Numeric<xsd_double>::ceil_result_cpp_type, Dynami
 
 template<>
 nonstd::expected<capabilities::Default<xsd_double>::cpp_type, DynamicError> capabilities::Numeric<xsd_double>::from_multiplicity(uint64_t multiplicity) noexcept {
-    auto const double_val = static_cast<cpp_type>(multiplicity);
-    if (static_cast<uint64_t>(double_val) != multiplicity) [[unlikely]] {
-        // didn't fit
+    constexpr auto available_mantissa_bits = std::numeric_limits<cpp_type>::digits;
+    auto const required_mantissa_bits = std::bit_width(multiplicity) - std::countr_zero(multiplicity);
+
+    if (required_mantissa_bits > available_mantissa_bits) [[unlikely]] {
+        // doesn't fit
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }
 
-    return double_val;
+    return static_cast<cpp_type>(multiplicity);
 }
 
 

--- a/src/rdf4cpp/datatypes/xsd/Double.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Double.cpp
@@ -48,6 +48,18 @@ nonstd::expected<capabilities::Numeric<xsd_double>::ceil_result_cpp_type, Dynami
     return std::ceil(operand);
 }
 
+template<>
+nonstd::expected<capabilities::Default<xsd_double>::cpp_type, DynamicError> capabilities::Numeric<xsd_double>::from_multiplicity(uint64_t multiplicity) noexcept {
+    auto const double_val = static_cast<cpp_type>(multiplicity);
+    if (static_cast<uint64_t>(double_val) != multiplicity) [[unlikely]] {
+        // didn't fit
+        return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
+    }
+
+    return double_val;
+}
+
+
 // A double stored as its shortest round-tripping decimal, i.e. as significand * 10^exponent.
 struct __attribute__((packed)) DecimalDoubleLayout {
     static constexpr size_t exponent_width = 6;

--- a/src/rdf4cpp/datatypes/xsd/Double.hpp
+++ b/src/rdf4cpp/datatypes/xsd/Double.hpp
@@ -38,6 +38,9 @@ template<>
 nonstd::expected<capabilities::Numeric<xsd_double>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<xsd_double>::ceil(cpp_type const &operand) noexcept;
 
 template<>
+nonstd::expected<capabilities::Default<xsd_double>::cpp_type, DynamicError> capabilities::Numeric<xsd_double>::from_multiplicity(uint64_t multiplicity) noexcept;
+
+template<>
 std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_double>::try_into_inlined(cpp_type const &value) noexcept;
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Float.cpp
@@ -47,6 +47,17 @@ nonstd::expected<capabilities::Numeric<xsd_float>::ceil_result_cpp_type, Dynamic
 }
 
 template<>
+nonstd::expected<capabilities::Default<xsd_float>::cpp_type, DynamicError> capabilities::Numeric<xsd_float>::from_multiplicity(uint64_t multiplicity) noexcept {
+    auto const float_val = static_cast<cpp_type>(multiplicity);
+    if (static_cast<uint64_t>(float_val) != multiplicity) [[unlikely]] {
+        // didn't fit
+        return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
+    }
+
+    return float_val;
+}
+
+template<>
 std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_float>::try_into_inlined(cpp_type const &value) noexcept {
     return util::pack<storage::identifier::LiteralID>(value);
 }

--- a/src/rdf4cpp/datatypes/xsd/Float.cpp
+++ b/src/rdf4cpp/datatypes/xsd/Float.cpp
@@ -48,13 +48,15 @@ nonstd::expected<capabilities::Numeric<xsd_float>::ceil_result_cpp_type, Dynamic
 
 template<>
 nonstd::expected<capabilities::Default<xsd_float>::cpp_type, DynamicError> capabilities::Numeric<xsd_float>::from_multiplicity(uint64_t multiplicity) noexcept {
-    auto const float_val = static_cast<cpp_type>(multiplicity);
-    if (static_cast<uint64_t>(float_val) != multiplicity) [[unlikely]] {
-        // didn't fit
+    constexpr auto available_mantissa_bits = std::numeric_limits<cpp_type>::digits;
+    auto const required_mantissa_bits = std::bit_width(multiplicity) - std::countr_zero(multiplicity);
+
+    if (required_mantissa_bits > available_mantissa_bits) [[unlikely]] {
+        // doesn't fit
         return nonstd::make_unexpected(DynamicError::InvalidValueForCast);
     }
 
-    return float_val;
+    return static_cast<cpp_type>(multiplicity);
 }
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/Float.hpp
+++ b/src/rdf4cpp/datatypes/xsd/Float.hpp
@@ -44,6 +44,9 @@ template<>
 nonstd::expected<capabilities::Numeric<xsd_float>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<xsd_float>::ceil(cpp_type const &operand) noexcept;
 
 template<>
+nonstd::expected<capabilities::Default<xsd_float>::cpp_type, DynamicError> capabilities::Numeric<xsd_float>::from_multiplicity(uint64_t multiplicity) noexcept;
+
+template<>
 std::optional<storage::identifier::LiteralID> capabilities::Inlineable<xsd_float>::try_into_inlined(cpp_type const &value) noexcept;
 
 template<>

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.cpp
@@ -61,6 +61,11 @@ nonstd::expected<capabilities::Numeric<xsd_integer>::ceil_result_cpp_type, Dynam
 }
 
 template<>
+nonstd::expected<capabilities::Default<xsd_integer>::cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::from_multiplicity(uint64_t multiplicity) noexcept {
+    return multiplicity; // any 64bit integer is exactly representable in boost::multiprecision::cpp_int
+}
+
+template<>
 std::partial_ordering capabilities::Comparable<xsd_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept {
     if (lhs < rhs) {
         return std::partial_ordering::less;

--- a/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
+++ b/src/rdf4cpp/datatypes/xsd/integers/signed/Integer.hpp
@@ -48,6 +48,9 @@ template<>
 nonstd::expected<capabilities::Numeric<xsd_integer>::ceil_result_cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::ceil(cpp_type const &operand) noexcept;
 
 template<>
+nonstd::expected<capabilities::Default<xsd_integer>::cpp_type, DynamicError> capabilities::Numeric<xsd_integer>::from_multiplicity(uint64_t multiplicity) noexcept;
+
+template<>
 std::partial_ordering capabilities::Comparable<xsd_integer>::compare(cpp_type const &lhs, cpp_type const &rhs) noexcept;
 
 template<>

--- a/tests/nodes/tests_Literal.cpp
+++ b/tests/nodes/tests_Literal.cpp
@@ -1662,3 +1662,77 @@ TEST_CASE("is_numeric/is_timepoint/is_duration regression") {
     CHECK_FALSE(n.is_duration());
     CHECK(n.is_numeric());
 }
+
+template<datatypes::NumericLiteralDatatype T>
+void check_from_multiplicity(uint64_t normal_value, Literal normal_value_expected, uint64_t huge_value, Literal huge_value_expected) {
+    SUBCASE(T::identifier.c_str()) {
+        SUBCASE("normal value") {
+            SUBCASE("comptime type") {
+                auto lit = Literal::make_from_multiplicity<T>(normal_value);
+                CHECK_EQ(lit.datatype(), normal_value_expected.datatype());
+                CHECK_EQ(lit, normal_value_expected);
+            }
+
+            SUBCASE("runtime type") {
+                auto lit = Literal::make_from_multiplicity(normal_value, IRI{T::datatype_id});
+                CHECK_EQ(lit.datatype(), normal_value_expected.datatype());
+                CHECK_EQ(lit, normal_value_expected);
+            }
+
+            SUBCASE("deferred") {
+                auto lit = make_deferred_from_multiplicity(normal_value, IRI{T::datatype_id});
+                CHECK_EQ(lit.datatype, normal_value_expected.datatype());
+                CHECK_EQ(materialize_deferred(lit), normal_value_expected);
+            }
+        }
+
+        SUBCASE("huge value") {
+            SUBCASE("comptime type") {
+                auto lit = Literal::make_from_multiplicity<T>(huge_value);
+                if (lit.null()) {
+                    CHECK(huge_value_expected.null());
+                } else {
+                    CHECK_EQ(lit, huge_value_expected);
+                }
+            }
+
+            SUBCASE("runtime type") {
+                auto lit = Literal::make_from_multiplicity(huge_value, IRI{T::datatype_id});
+                if (lit.null()) {
+                    CHECK(huge_value_expected.null());
+                } else {
+                    CHECK_EQ(lit, huge_value_expected);
+                }
+            }
+
+            SUBCASE("deferred") {
+                auto lit = make_deferred_from_multiplicity(huge_value, IRI{T::datatype_id});
+                if (lit.null()) {
+                    CHECK(huge_value_expected.null());
+                } else {
+                    CHECK_EQ(materialize_deferred(lit), huge_value_expected);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("from_multiplicity") {
+    using namespace datatypes;
+
+    constexpr uint64_t huge_val = std::numeric_limits<uint64_t>::max();
+
+    check_from_multiplicity<xsd::Integer>(42, 42_xsd_integer, huge_val, Literal::make_typed_from_value<xsd::Integer>(huge_val));
+    check_from_multiplicity<xsd::Decimal>(42, "42.0"_xsd_decimal, huge_val, Literal::make_typed_from_value<xsd::Decimal>(xsd::Decimal::cpp_type{huge_val}));
+    check_from_multiplicity<xsd::Float>(42, 42.0_xsd_float, huge_val, Literal{});
+    check_from_multiplicity<xsd::Double>(42, 42.0_xsd_double, huge_val, Literal{});
+    check_from_multiplicity<owl::Rational>(42, Literal::make_typed_from_value<owl::Rational>(42), huge_val, Literal::make_typed_from_value<owl::Rational>(huge_val));
+    check_from_multiplicity<owl::Real>(42, Literal::make_typed_from_value<owl::Real>(42), huge_val, Literal::make_typed_from_value<owl::Real>(huge_val));
+
+    // stub-numeric
+    check_from_multiplicity<xsd::Int>(42, 42_xsd_integer, huge_val, Literal::make_typed_from_value<xsd::Integer>(huge_val));
+
+    // non-numeric
+    // CHECK(Literal::make_from_multiplicity<xsd::Boolean>(42).null()); does not compile, OK
+    CHECK(Literal::make_from_multiplicity(42, IRI::datatype<xsd::Boolean>()).null());
+}


### PR DESCRIPTION
Use multiplication by multiplicity if datatype is exact instead of loop.

Introduces a new registry function:
`Literal::from_multiplicity(uint64_t, IRI datatype)` for that purpose.